### PR TITLE
Fix some warnings

### DIFF
--- a/examples/ping_pong.rs
+++ b/examples/ping_pong.rs
@@ -21,14 +21,17 @@ use webrtc_ice::agent::Agent;
 #[macro_use]
 extern crate lazy_static;
 
+type SenderType = Arc<Mutex<mpsc::Sender<String>>>;
+type ReceiverType = Arc<Mutex<mpsc::Receiver<String>>>;
+
 lazy_static! {
     // ErrUnknownType indicates an error with Unknown info.
-    static ref REMOTE_AUTH_CHANNEL: (Arc<Mutex<mpsc::Sender<String>>>, Arc<Mutex<mpsc::Receiver<String>>>) = {
+    static ref REMOTE_AUTH_CHANNEL: (SenderType, ReceiverType ) = {
         let (tx, rx) = mpsc::channel::<String>(3);
         (Arc::new(Mutex::new(tx)), Arc::new(Mutex::new(rx)))
     };
 
-    static ref REMOTE_CAND_CHANNEL: (Arc<Mutex<mpsc::Sender<String>>>, Arc<Mutex<mpsc::Receiver<String>>>) = {
+    static ref REMOTE_CAND_CHANNEL: (SenderType, ReceiverType) = {
         let (tx, rx) = mpsc::channel::<String>(10);
         (Arc::new(Mutex::new(tx)), Arc::new(Mutex::new(rx)))
     };
@@ -180,7 +183,7 @@ async fn main() -> Result<(), Error> {
                                 remote_http_port
                             ))
                             .header("content-type", "application/json")
-                            .body(Body::from(format!("{}", c.marshal())))
+                            .body(Body::from(c.marshal()))
                         {
                             Ok(req) => req,
                             Err(err) => {

--- a/src/agent/agent_gather_test.rs
+++ b/src/agent/agent_gather_test.rs
@@ -47,10 +47,10 @@ async fn test_vnet_gather_dynamic_ip_address() -> Result<(), Error> {
 
     for ip in &local_ips {
         if ip.is_loopback() {
-            assert!(false, "should not return loopback IP");
+            panic!("should not return loopback IP");
         }
         if !ipnet.contains(ip) {
-            assert!(false, "{} should be contained in the CIDR {}", ip, ipnet);
+            panic!("{} should be contained in the CIDR {}", ip, ipnet);
         }
     }
 
@@ -180,7 +180,7 @@ async fn test_vnet_gather_with_nat_1to1_as_host_candidates() -> Result<(), Error
         }
     }
 
-    if &candidates[0].address() == external_ip0 {
+    if candidates[0].address() == external_ip0 {
         assert_eq!(
             candidates[1].address(),
             external_ip1,
@@ -199,7 +199,7 @@ async fn test_vnet_gather_with_nat_1to1_as_host_candidates() -> Result<(), Error
             "Unexpected listen IP: {}",
             laddrs[1].ip()
         );
-    } else if &candidates[0].address() == external_ip1 {
+    } else if candidates[0].address() == external_ip1 {
         assert_eq!(
             candidates[1].address(),
             external_ip0,
@@ -296,7 +296,7 @@ async fn test_vnet_gather_with_nat_1to1_as_srflx_candidates() -> Result<(), Erro
                 candi_srflx = Some(candidate);
             }
             _ => {
-                assert!(false, "Unexpected candidate type");
+                panic!("Unexpected candidate type");
             }
         }
     }
@@ -346,11 +346,7 @@ async fn test_vnet_gather_with_interface_filter() -> Result<(), Error> {
         let a = Agent::new(AgentConfig {
             net: Some(Arc::clone(&nw)),
             interface_filter: Some(Box::new(|interface_name: &str| -> bool {
-                if "eth0" == interface_name {
-                    true
-                } else {
-                    false
-                }
+                "eth0" == interface_name
             })),
             ..Default::default()
         })
@@ -378,7 +374,6 @@ async fn test_vnet_gather_turn_connection_leak() -> Result<(), Error> {
         username: "user".to_owned(),
         password: "pass".to_owned(),
         proto: ProtoType::Udp,
-        ..Default::default()
     };
 
     // buildVNet with a Symmetric NATs for both LANs

--- a/src/agent/agent_test.rs
+++ b/src/agent/agent_test.rs
@@ -90,7 +90,6 @@ async fn test_pair_priority() -> Result<(), Error> {
         },
         rel_addr: "4.3.2.1".to_owned(),
         rel_port: 43212,
-        ..Default::default()
     };
 
     let srflx_remote = srflx_config
@@ -107,7 +106,6 @@ async fn test_pair_priority() -> Result<(), Error> {
         },
         rel_addr: "4.3.2.1".to_owned(),
         rel_port: 43211,
-        ..Default::default()
     };
 
     let prflx_remote = prflx_config
@@ -161,7 +159,7 @@ async fn test_pair_priority() -> Result<(), Error> {
                     remote.to_string(),
                 );
             } else {
-                assert!(false, "expected Some, but got None");
+                panic!("expected Some, but got None");
             }
         }
     }
@@ -310,8 +308,7 @@ async fn test_handle_peer_reflexive_udp_pflx_candidate() -> Result<(), Error> {
 
             assert_eq!(c.port(), 999, "Port number mismatch");
         } else {
-            assert!(
-                false,
+            panic!(
                 "expected non-empty remote candidate for network type {}",
                 local.network_type()
             );
@@ -914,18 +911,18 @@ async fn test_connection_state_callback() -> Result<(), Error> {
     let cfg0 = AgentConfig {
         urls: vec![],
         network_types: supported_network_types(),
-        disconnected_timeout: Some(disconnected_duration.clone()),
-        failed_timeout: Some(failed_duration.clone()),
-        keepalive_interval: Some(keepalive_interval.clone()),
+        disconnected_timeout: Some(disconnected_duration),
+        failed_timeout: Some(failed_duration),
+        keepalive_interval: Some(keepalive_interval),
         ..Default::default()
     };
 
     let cfg1 = AgentConfig {
         urls: vec![],
         network_types: supported_network_types(),
-        disconnected_timeout: Some(disconnected_duration.clone()),
-        failed_timeout: Some(failed_duration.clone()),
-        keepalive_interval: Some(keepalive_interval.clone()),
+        disconnected_timeout: Some(disconnected_duration),
+        failed_timeout: Some(failed_duration),
+        keepalive_interval: Some(keepalive_interval),
         ..Default::default()
     };
 
@@ -1068,7 +1065,6 @@ async fn test_candidate_pair_stats() -> Result<(), Error> {
             },
             rel_addr: "4.3.2.1".to_owned(),
             rel_port: 43212,
-            ..Default::default()
         }
         .new_candidate_server_reflexive(Some(Arc::clone(&a.agent_internal)))
         .await?,
@@ -1085,7 +1081,6 @@ async fn test_candidate_pair_stats() -> Result<(), Error> {
             },
             rel_addr: "4.3.2.1".to_owned(),
             rel_port: 43211,
-            ..Default::default()
         }
         .new_candidate_peer_reflexive(Some(Arc::clone(&a.agent_internal)))
         .await?,
@@ -1113,10 +1108,10 @@ async fn test_candidate_pair_stats() -> Result<(), Error> {
         Arc::clone(&host_remote),
     ] {
         let mut ai = a.agent_internal.lock().await;
-        let p = ai.find_pair(&host_local, &remote).await;
+        let p = ai.find_pair(&host_local, remote).await;
 
         if p.is_none() {
-            ai.add_pair(Arc::clone(&host_local), Arc::clone(&remote))
+            ai.add_pair(Arc::clone(&host_local), Arc::clone(remote))
                 .await;
         }
     }
@@ -1155,7 +1150,7 @@ async fn test_candidate_pair_stats() -> Result<(), Error> {
         } else if cps.remote_candidate_id == host_remote.id() {
             host_pair_stat = cps;
         } else {
-            assert!(false, "invalid remote candidate ID");
+            panic!("invalid remote candidate ID");
         }
     }
 
@@ -1221,7 +1216,6 @@ async fn test_local_candidate_stats() -> Result<(), Error> {
             },
             rel_addr: "4.3.2.1".to_owned(),
             rel_port: 43212,
-            ..Default::default()
         }
         .new_candidate_server_reflexive(Some(Arc::clone(&a.agent_internal)))
         .await?,
@@ -1253,8 +1247,7 @@ async fn test_local_candidate_stats() -> Result<(), Error> {
             srflx_local_stat = stats.clone();
             Arc::clone(&srflx_local)
         } else {
-            assert!(false, "invalid local candidate ID");
-            Arc::clone(&srflx_local)
+            panic!("invalid local candidate ID");
         };
 
         assert_eq!(
@@ -1318,7 +1311,6 @@ async fn test_remote_candidate_stats() -> Result<(), Error> {
             },
             rel_addr: "4.3.2.1".to_owned(),
             rel_port: 43212,
-            ..Default::default()
         }
         .new_candidate_server_reflexive(Some(Arc::clone(&a.agent_internal)))
         .await?,
@@ -1335,7 +1327,6 @@ async fn test_remote_candidate_stats() -> Result<(), Error> {
             },
             rel_addr: "4.3.2.1".to_owned(),
             rel_port: 43211,
-            ..Default::default()
         }
         .new_candidate_peer_reflexive(Some(Arc::clone(&a.agent_internal)))
         .await?,
@@ -1397,8 +1388,7 @@ async fn test_remote_candidate_stats() -> Result<(), Error> {
             host_remote_stat = stats.clone();
             Arc::clone(&host_remote)
         } else {
-            assert!(false, "invalid remote candidate ID");
-            Arc::clone(&host_remote)
+            panic!("invalid remote candidate ID");
         };
 
         assert_eq!(
@@ -1479,7 +1469,7 @@ async fn test_init_ext_ip_mapping() -> Result<(), Error> {
             err
         );
     } else {
-        assert!(false, "expected error, but got ok");
+        panic!("expected error, but got ok");
     }
 
     // NewAgent should return an error when 1:1 NAT for srflx candidate is enabled
@@ -1498,7 +1488,7 @@ async fn test_init_ext_ip_mapping() -> Result<(), Error> {
             err
         );
     } else {
-        assert!(false, "expected error, but got ok");
+        panic!("expected error, but got ok");
     }
 
     // NewAgent should return an error when 1:1 NAT for host candidate is enabled
@@ -1517,7 +1507,7 @@ async fn test_init_ext_ip_mapping() -> Result<(), Error> {
             err
         );
     } else {
-        assert!(false, "expected error, but got ok");
+        panic!("expected error, but got ok");
     }
 
     // NewAgent should return if newExternalIPMapper() returns an error.
@@ -1534,7 +1524,7 @@ async fn test_init_ext_ip_mapping() -> Result<(), Error> {
             err
         );
     } else {
-        assert!(false, "expected error, but got ok");
+        panic!("expected error, but got ok");
     }
 
     Ok(())
@@ -1603,7 +1593,7 @@ async fn test_agent_credentials() -> Result<(), Error> {
     {
         assert_eq!(err, *ERR_LOCAL_UFRAG_INSUFFICIENT_BITS);
     } else {
-        assert!(false, "expected error, but got ok");
+        panic!("expected error, but got ok");
     }
 
     if let Err(err) = Agent::new(AgentConfig {
@@ -1614,7 +1604,7 @@ async fn test_agent_credentials() -> Result<(), Error> {
     {
         assert_eq!(err, *ERR_LOCAL_PWD_INSUFFICIENT_BITS);
     } else {
-        assert!(false, "expected error, but got ok");
+        panic!("expected error, but got ok");
     }
 
     Ok(())
@@ -1629,16 +1619,16 @@ async fn test_connection_state_failed_delete_all_candidates() -> Result<(), Erro
 
     let cfg0 = AgentConfig {
         network_types: supported_network_types(),
-        disconnected_timeout: Some(one_second.clone()),
-        failed_timeout: Some(one_second.clone()),
-        keepalive_interval: Some(keepalive_interval.clone()),
+        disconnected_timeout: Some(one_second),
+        failed_timeout: Some(one_second),
+        keepalive_interval: Some(keepalive_interval),
         ..Default::default()
     };
     let cfg1 = AgentConfig {
         network_types: supported_network_types(),
-        disconnected_timeout: Some(one_second.clone()),
-        failed_timeout: Some(one_second.clone()),
-        keepalive_interval: Some(keepalive_interval.clone()),
+        disconnected_timeout: Some(one_second),
+        failed_timeout: Some(one_second),
+        keepalive_interval: Some(keepalive_interval),
         ..Default::default()
     };
 
@@ -1681,15 +1671,15 @@ async fn test_connection_state_connecting_to_failed() -> Result<(), Error> {
     let keepalive_interval = Duration::from_secs(0);
 
     let cfg0 = AgentConfig {
-        disconnected_timeout: Some(one_second.clone()),
-        failed_timeout: Some(one_second.clone()),
-        keepalive_interval: Some(keepalive_interval.clone()),
+        disconnected_timeout: Some(one_second),
+        failed_timeout: Some(one_second),
+        keepalive_interval: Some(keepalive_interval),
         ..Default::default()
     };
     let cfg1 = AgentConfig {
-        disconnected_timeout: Some(one_second.clone()),
-        failed_timeout: Some(one_second.clone()),
-        keepalive_interval: Some(keepalive_interval.clone()),
+        disconnected_timeout: Some(one_second),
+        failed_timeout: Some(one_second),
+        keepalive_interval: Some(keepalive_interval),
         ..Default::default()
     };
 
@@ -1713,7 +1703,7 @@ async fn test_connection_state_connecting_to_failed() -> Result<(), Error> {
                     let mut c = wc_clone.lock().await;
                     c.take();
                 } else if c == ConnectionState::Connected || c == ConnectionState::Completed {
-                    assert!(false, "Unexpected ConnectionState: {}", c);
+                    panic!("Unexpected ConnectionState: {}", c);
                 }
             })
         });
@@ -1770,7 +1760,7 @@ async fn test_agent_restart_during_gather() -> Result<(), Error> {
     if let Err(err) = agent.restart("".to_owned(), "".to_owned()).await {
         assert_eq!(err, *ERR_RESTART_WHEN_GATHERING);
     } else {
-        assert!(false, "expected error, but got ok");
+        panic!("expected error, but got ok");
     }
 
     agent.close().await?;
@@ -1788,7 +1778,7 @@ async fn test_agent_restart_when_closed() -> Result<(), Error> {
     if let Err(err) = agent.restart("".to_owned(), "".to_owned()).await {
         assert_eq!(err, *ERR_CLOSED);
     } else {
-        assert!(false, "expected error, but got ok");
+        panic!("expected error, but got ok");
     }
 
     Ok(())
@@ -1801,13 +1791,13 @@ async fn test_agent_restart_one_side() -> Result<(), Error> {
     //"Restart One Side"
     let (_, _, agent_a, agent_b) = pipe(
         Some(AgentConfig {
-            disconnected_timeout: Some(one_second.clone()),
-            failed_timeout: Some(one_second.clone()),
+            disconnected_timeout: Some(one_second),
+            failed_timeout: Some(one_second),
             ..Default::default()
         }),
         Some(AgentConfig {
-            disconnected_timeout: Some(one_second.clone()),
-            failed_timeout: Some(one_second.clone()),
+            disconnected_timeout: Some(one_second),
+            failed_timeout: Some(one_second),
             ..Default::default()
         }),
     )
@@ -1861,13 +1851,13 @@ async fn test_agent_restart_both_side() -> Result<(), Error> {
     // Store the original candidates, confirm that after we reconnect we have new pairs
     let (_, _, agent_a, agent_b) = pipe(
         Some(AgentConfig {
-            disconnected_timeout: Some(one_second.clone()),
-            failed_timeout: Some(one_second.clone()),
+            disconnected_timeout: Some(one_second),
+            failed_timeout: Some(one_second),
             ..Default::default()
         }),
         Some(AgentConfig {
-            disconnected_timeout: Some(one_second.clone()),
-            failed_timeout: Some(one_second.clone()),
+            disconnected_timeout: Some(one_second),
+            failed_timeout: Some(one_second),
             ..Default::default()
         }),
     )

--- a/src/agent/agent_transport_test.rs
+++ b/src/agent/agent_transport_test.rs
@@ -93,8 +93,8 @@ async fn test_remote_local_addr() -> Result<(), Error> {
         let b_laddr = cb.local_addr().await?;
 
         // Assert addresses
-        assert_eq!(a_laddr.ip().to_string(), format!("{}", VNET_LOCAL_IPA),);
-        assert_eq!(b_laddr.ip().to_string(), format!("{}", VNET_LOCAL_IPB),);
+        assert_eq!(a_laddr.ip().to_string(), VNET_LOCAL_IPA.to_string());
+        assert_eq!(b_laddr.ip().to_string(), VNET_LOCAL_IPB.to_string());
 
         // Close
         //ca.close().await?;
@@ -109,7 +109,7 @@ async fn test_remote_local_addr() -> Result<(), Error> {
 #[tokio::test]
 async fn test_conn_stats() -> Result<(), Error> {
     let (ca, cb, _, _) = pipe(None, None).await?;
-    let na = ca.send(&vec![0u8; 10]).await?;
+    let na = ca.send(&[0u8; 10]).await?;
 
     let wg = WaitGroup::new();
 

--- a/src/agent/agent_vnet_test.rs
+++ b/src/agent/agent_vnet_test.rs
@@ -528,7 +528,6 @@ async fn test_connectivity_vnet_full_cone_nats_on_both_ends() -> Result<(), Erro
         username: "user".to_owned(),
         password: "pass".to_owned(),
         proto: ProtoType::Udp,
-        ..Default::default()
     };
 
     // buildVNet with a Full-cone NATs both LANs
@@ -591,7 +590,6 @@ async fn test_connectivity_vnet_symmetric_nats_on_both_ends() -> Result<(), Erro
         username: "user".to_owned(),
         password: "pass".to_owned(),
         proto: ProtoType::Udp,
-        ..Default::default()
     };
 
     // buildVNet with a Symmetric NATs for both LANs
@@ -660,7 +658,6 @@ async fn test_connectivity_vnet_1to1_nat_with_host_candidate_vs_symmetric_nats()
     let a0test_config = AgentTestConfig {
         urls: vec![],
         nat_1to1_ip_candidate_type: CandidateType::Host, // Use 1:1 NAT IP as a host candidate
-        ..Default::default()
     };
     let a1test_config = AgentTestConfig {
         urls: vec![],
@@ -714,7 +711,6 @@ async fn test_connectivity_vnet_1to1_nat_with_srflx_candidate_vs_symmetric_nats(
     let a0test_config = AgentTestConfig {
         urls: vec![],
         nat_1to1_ip_candidate_type: CandidateType::ServerReflexive, // Use 1:1 NAT IP as a srflx candidate
-        ..Default::default()
     };
     let a1test_config = AgentTestConfig {
         urls: vec![],
@@ -795,9 +791,9 @@ async fn test_disconnected_to_connected() -> Result<(), Error> {
             network_types: supported_network_types(),
             multicast_dns_mode: MulticastDnsMode::Disabled,
             net: Some(Arc::clone(&net0)),
-            disconnected_timeout: Some(disconnected_timeout.clone()),
-            keepalive_interval: Some(keepalive_interval.clone()),
-            check_interval: keepalive_interval.clone(),
+            disconnected_timeout: Some(disconnected_timeout),
+            keepalive_interval: Some(keepalive_interval),
+            check_interval: keepalive_interval,
             ..Default::default()
         })
         .await?,
@@ -808,9 +804,9 @@ async fn test_disconnected_to_connected() -> Result<(), Error> {
             network_types: supported_network_types(),
             multicast_dns_mode: MulticastDnsMode::Disabled,
             net: Some(Arc::clone(&net1)),
-            disconnected_timeout: Some(disconnected_timeout.clone()),
-            keepalive_interval: Some(keepalive_interval.clone()),
-            check_interval: keepalive_interval.clone(),
+            disconnected_timeout: Some(disconnected_timeout),
+            keepalive_interval: Some(keepalive_interval),
+            check_interval: keepalive_interval,
             ..Default::default()
         })
         .await?,
@@ -917,9 +913,7 @@ async fn test_write_use_valid_pair() -> Result<(), Error> {
                 ..Default::default()
             };
             let result = m.decode();
-            if result.is_err() {
-                return false;
-            } else if m.contains(stun::attributes::ATTR_USE_CANDIDATE) {
+            if result.is_err() | m.contains(stun::attributes::ATTR_USE_CANDIDATE) {
                 return false;
             }
         }

--- a/src/candidate/candidate_base.rs
+++ b/src/candidate/candidate_base.rs
@@ -469,7 +469,6 @@ impl CandidateBase {
                     "Discarded message from {}, not a valid remote candidate",
                     c.addr().await
                 );
-                return;
             } else if let Err(err) = ai.agent_conn.buffer.write(buf).await {
                 // NOTE This will return packetio.ErrFull if the buffer ever manages to fill up.
                 log::warn!("failed to write packet: {}", err);

--- a/src/candidate/candidate_test.rs
+++ b/src/candidate/candidate_test.rs
@@ -339,7 +339,7 @@ async fn test_candidate_marshal() -> Result<(), Error> {
                 );
                 assert_eq!(marshaled, actual_candidate.marshal());
             } else {
-                assert!(false, "expected ok");
+                panic!("expected ok");
             }
         } else {
             assert!(actual_candidate.is_err(), "expected error");

--- a/src/control/control_test.rs
+++ b/src/control/control_test.rs
@@ -8,7 +8,7 @@ fn test_controlled_get_from() -> Result<(), Error> {
     if let Err(err) = result {
         assert_eq!(err, *ERR_ATTRIBUTE_NOT_FOUND, "unexpected error");
     } else {
-        assert!(false, "expected error, but got ok");
+        panic!("expected error, but got ok");
     }
 
     m.build(&[Box::new(BINDING_REQUEST), Box::new(c)])?;
@@ -24,13 +24,13 @@ fn test_controlled_get_from() -> Result<(), Error> {
     //"IncorrectSize"
     {
         let mut m3 = Message::new();
-        m3.add(ATTR_ICE_CONTROLLED, &vec![0; 100]);
+        m3.add(ATTR_ICE_CONTROLLED, &[0; 100]);
         let mut c2 = AttrControlled::default();
         let result = c2.get_from(&m3);
         if let Err(err) = result {
             assert!(is_attr_size_invalid(&err), "should error");
         } else {
-            assert!(false, "expected error, but got ok");
+            panic!("expected error, but got ok");
         }
     }
 
@@ -45,7 +45,7 @@ fn test_controlling_get_from() -> Result<(), Error> {
     if let Err(err) = result {
         assert_eq!(err, *ERR_ATTRIBUTE_NOT_FOUND, "unexpected error");
     } else {
-        assert!(false, "expected error, but got ok");
+        panic!("expected error, but got ok");
     }
 
     m.build(&[Box::new(BINDING_REQUEST), Box::new(c)])?;
@@ -61,13 +61,13 @@ fn test_controlling_get_from() -> Result<(), Error> {
     //"IncorrectSize"
     {
         let mut m3 = Message::new();
-        m3.add(ATTR_ICE_CONTROLLING, &vec![0; 100]);
+        m3.add(ATTR_ICE_CONTROLLING, &[0; 100]);
         let mut c2 = AttrControlling::default();
         let result = c2.get_from(&m3);
         if let Err(err) = result {
             assert!(is_attr_size_invalid(&err), "should error");
         } else {
-            assert!(false, "expected error, but got ok");
+            panic!("expected error, but got ok");
         }
     }
 
@@ -84,7 +84,7 @@ fn test_control_get_from() -> Result<(), Error> {
         if let Err(err) = result {
             assert_eq!(err, *ERR_ATTRIBUTE_NOT_FOUND, "unexpected error");
         } else {
-            assert!(false, "expected error, but got ok");
+            panic!("expected error, but got ok");
         }
     }
     //"Controlling"
@@ -95,7 +95,7 @@ fn test_control_get_from() -> Result<(), Error> {
         if let Err(err) = result {
             assert_eq!(err, *ERR_ATTRIBUTE_NOT_FOUND, "unexpected error");
         } else {
-            assert!(false, "expected error, but got ok");
+            panic!("expected error, but got ok");
         }
 
         c.role = Role::Controlling;
@@ -114,13 +114,13 @@ fn test_control_get_from() -> Result<(), Error> {
         //"IncorrectSize"
         {
             let mut m3 = Message::new();
-            m3.add(ATTR_ICE_CONTROLLING, &vec![0; 100]);
+            m3.add(ATTR_ICE_CONTROLLING, &[0; 100]);
             let mut c2 = AttrControl::default();
             let result = c2.get_from(&m3);
             if let Err(err) = result {
                 assert!(is_attr_size_invalid(&err), "should error");
             } else {
-                assert!(false, "expected error, but got ok");
+                panic!("expected error, but got ok");
             }
         }
     }
@@ -133,7 +133,7 @@ fn test_control_get_from() -> Result<(), Error> {
         if let Err(err) = result {
             assert_eq!(err, *ERR_ATTRIBUTE_NOT_FOUND, "unexpected error");
         } else {
-            assert!(false, "expected error, but got ok");
+            panic!("expected error, but got ok");
         }
 
         c.role = Role::Controlled;
@@ -152,13 +152,13 @@ fn test_control_get_from() -> Result<(), Error> {
         //"IncorrectSize"
         {
             let mut m3 = Message::new();
-            m3.add(ATTR_ICE_CONTROLLING, &vec![0; 100]);
+            m3.add(ATTR_ICE_CONTROLLING, &[0; 100]);
             let mut c2 = AttrControl::default();
             let result = c2.get_from(&m3);
             if let Err(err) = result {
                 assert!(is_attr_size_invalid(&err), "should error");
             } else {
-                assert!(false, "expected error, but got ok");
+                panic!("expected error, but got ok");
             }
         }
     }

--- a/src/mdns/mdns_test.rs
+++ b/src/mdns/mdns_test.rs
@@ -87,7 +87,7 @@ async fn test_multicast_dns_static_host_name() -> Result<(), Error> {
     if let Err(err) = Agent::new(cfg0).await {
         assert_eq!(err, *ERR_INVALID_MULTICAST_DNSHOST_NAME);
     } else {
-        assert!(false, "expected error, but got ok");
+        panic!("expected error, but got ok");
     }
 
     let cfg1 = AgentConfig {
@@ -139,7 +139,7 @@ fn test_generate_multicast_dnsname() -> Result<(), Error> {
             name
         );
     } else {
-        assert!(false, "expected ok, but got err");
+        panic!("expected ok, but got err");
     }
 
     Ok(())

--- a/src/priority/priority_test.rs
+++ b/src/priority/priority_test.rs
@@ -10,7 +10,7 @@ fn test_priority_get_from() -> Result<(), Error> {
     if let Err(err) = result {
         assert_eq!(err, ERR_ATTRIBUTE_NOT_FOUND.clone(), "unexpected error");
     } else {
-        assert!(false, "expected error, but got ok");
+        panic!("expected error, but got ok");
     }
 
     m.build(&[Box::new(BINDING_REQUEST), Box::new(p)])?;
@@ -26,13 +26,13 @@ fn test_priority_get_from() -> Result<(), Error> {
     //"IncorrectSize"
     {
         let mut m3 = Message::new();
-        m3.add(ATTR_PRIORITY, &vec![0; 100]);
+        m3.add(ATTR_PRIORITY, &[0; 100]);
         let mut p2 = PriorityAttr::default();
         let result = p2.get_from(&m3);
         if let Err(err) = result {
             assert!(is_attr_size_invalid(&err), "should error");
         } else {
-            assert!(false, "expected error, but got ok");
+            panic!("expected error, but got ok");
         }
     }
 

--- a/src/url/url_test.rs
+++ b/src/url/url_test.rs
@@ -131,7 +131,7 @@ fn test_parse_url_failure() -> Result<(), Error> {
         if let Err(err) = result {
             assert_eq!(err, expected_err, "testCase:{}", raw_url);
         } else {
-            assert!(false, "expected error, but got ok");
+            panic!("expected error, but got ok");
         }
     }
 

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -158,5 +158,5 @@ pub(crate) async fn listen_udp_in_port_range(
         }
     }
 
-    return Err(ERR_PORT.to_owned());
+    Err(ERR_PORT.to_owned())
 }


### PR DESCRIPTION
Hello, I saw this issue https://github.com/webrtc-rs/webrtc/issues/56 and I thought I could start by fixing normal warnings, like using `.clone()` on a struct that implements `Copy` and so on. They are all minor modifications.

And, I was wondering if I could keep working on this issue, maybe try fixing `clippy::pedantic` warnings while reading the suggested links in the original issue?