### PR TITLE
Allow dropping cancel_tx when awaiting on Agent::dial and Agent::accept

### DIFF
--- a/src/agent/agent_test.rs
+++ b/src/agent/agent_test.rs
@@ -450,7 +450,7 @@ async fn test_connectivity_on_startup() -> Result<()> {
     tokio::spawn(async move {
         let result = a_agent.accept(a_cancel_rx, b_ufrag, b_pwd).await;
         assert!(result.is_ok(), "agent accept expected OK");
-        drop(accepted_tx);
+        let _ = accepted_tx.send(()).await;
     });
 
     let _ = accepting_rx.recv().await;
@@ -815,7 +815,7 @@ async fn test_invalid_agent_starts() -> Result<()> {
     let (cancel_tx3, cancel_rx3) = mpsc::channel(1);
     tokio::spawn(async move {
         tokio::time::sleep(Duration::from_millis(100)).await;
-        drop(cancel_tx3);
+        let _ = cancel_tx3.send(()).await;
     });
 
     let result = a.dial(cancel_rx3, "foo".to_owned(), "bar".to_owned()).await;

--- a/src/agent/agent_transport.rs
+++ b/src/agent/agent_transport.rs
@@ -27,7 +27,7 @@ impl Agent {
             // block until pair selected
             tokio::select! {
                 _ = on_connected_rx.recv() => {},
-                _ = cancel_rx.recv() => {
+                Some(()) = cancel_rx.recv() => {
                     return Err(Error::ErrCanceledByCaller.into());
                 }
             }
@@ -55,7 +55,7 @@ impl Agent {
             // block until pair selected
             tokio::select! {
                 _ = on_connected_rx.recv() => {},
-                _ = cancel_rx.recv() => {
+                Some(()) = cancel_rx.recv() => {
                     return Err(Error::ErrCanceledByCaller.into());
                 }
             }


### PR DESCRIPTION
Hey, thanks a lot for this library!

I was connecting on another task with a sent cancel_rx, and dropping the cancel_tx would cancel the operation instead of continuing, as `cancel_rx.recv()` returns None when the channel has been closed. This could also be hit by users ignoring the binding by using _ when binding the Sender, such as:

```rust
// This does not bind the Sender, dropping it immediatly, which would be considered a cancel in the old code.
let (_, cancel_rx) = mpsc::channel(1);
```

A simple way to check the old vs new behavior in ping_pong.rs is to add a drop(cancel_tx) before dialing, such as:

```rust
let (cancel_tx, cancel_rx) = mpsc::channel(1);
drop(cancel_tx);
// Start the ICE Agent. One side must be controlled, and the other must be controlling
let conn: Arc<dyn Conn + Send + Sync> = if is_controlling {
    ice_agent.dial(cancel_rx, remote_ufrag, remote_pwd).await?
} else {
    ice_agent
        .accept(cancel_rx, remote_ufrag, remote_pwd)
        .await?
};
```

Maybe a test could be added checking this behavior, I can give it a try if you want.