### PR TITLE
Document cancel_rx behavior on Agent::dial and Agent::accept

### DIFF
--- a/src/agent/agent_transport.rs
+++ b/src/agent/agent_transport.rs
@@ -9,6 +9,9 @@ use util::Conn;
 impl Agent {
     /// Connects to the remote agent, acting as the controlling ice agent.
     /// The method blocks until at least one ice candidate pair has successfully connected.
+    ///
+    /// The operation will be cancelled if `cancel_rx` either receives a message or its channel
+    /// closes.
     pub async fn dial(
         &self,
         mut cancel_rx: mpsc::Receiver<()>,
@@ -37,6 +40,9 @@ impl Agent {
 
     /// Connects to the remote agent, acting as the controlled ice agent.
     /// The method blocks until at least one ice candidate pair has successfully connected.
+    ///
+    /// The operation will be cancelled if `cancel_rx` either receives a message or its channel
+    /// closes.
     pub async fn accept(
         &self,
         mut cancel_rx: mpsc::Receiver<()>,


### PR DESCRIPTION
This is a followup to #10, intending to make it clear to users how `cancel_rx` behaves.

Thanks a lot (again) for maintaining this library!