### PR TITLE
UDP Mux support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ ipnet = "2.3.0"
 clap = "2"
 lazy_static = "1.3.0"
 hyper = { version = "0.14.13", features = ["full"] }
+sha-1 = "0.9.1"
 
 [[example]]
 name = "ping_pong"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/webrtc-rs/ice"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-util = { package = "webrtc-util", version = "0.5.0", default-features = false, features = ["conn", "vnet"] }
+util = { package = "webrtc-util", version = "0.5.1", default-features = false, features = ["conn", "vnet", "sync"] }
 mdns = { package = "webrtc-mdns", version = "0.4.0" }
 stun = "0.4.0"
 turn = "0.5.0"

--- a/examples/ping_pong.rs
+++ b/examples/ping_pong.rs
@@ -109,7 +109,7 @@ async fn main() -> Result<(), Error> {
         .setting(AppSettings::DeriveDisplayOrder)
         .setting(AppSettings::SubcommandsNegateReqs)
         .arg(
-            Arg::with_name("use mux")
+            Arg::with_name("use-mux")
                 .takes_value(false)
                 .long("use-mux")
                 .short("m")
@@ -135,7 +135,7 @@ async fn main() -> Result<(), Error> {
     }
 
     let is_controlling = matches.is_present("controlling");
-    let use_mux = matches.is_present("use mux");
+    let use_mux = matches.is_present("use-mux");
 
     let (local_http_port, remote_http_port) = if is_controlling {
         (9000, 9001)
@@ -176,25 +176,14 @@ async fn main() -> Result<(), Error> {
         UDPNetwork::Ephemeral(Default::default())
     };
 
-    let ice_agent = if is_controlling {
-        Arc::new(
-            Agent::new(AgentConfig {
-                network_types: vec![NetworkType::Udp4],
-                udp_network,
-                ..Default::default()
-            })
-            .await?,
-        )
-    } else {
-        Arc::new(
-            Agent::new(AgentConfig {
-                network_types: vec![NetworkType::Udp4],
-                udp_network,
-                ..Default::default()
-            })
-            .await?,
-        )
-    };
+    let ice_agent = Arc::new(
+        Agent::new(AgentConfig {
+            network_types: vec![NetworkType::Udp4],
+            udp_network,
+            ..Default::default()
+        })
+        .await?,
+    );
 
     let client = Arc::new(Client::new());
 

--- a/src/agent/agent_config.rs
+++ b/src/agent/agent_config.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::error::*;
 use crate::mdns::*;
 use crate::network_type::*;
+use crate::udp_mux::UDPMux;
 use crate::url::*;
 
 use util::vnet::net::*;
@@ -138,6 +139,11 @@ pub struct AgentConfig {
     /// Net is the our abstracted network interface for internal development purpose only
     /// (see (github.com/pion/transport/vnet)[github.com/pion/transport/vnet]).
     pub net: Option<Arc<Net>>,
+
+    /// UDPMux is used for multiplexing multiple incoming UDP connections on a single port
+    /// when this is set, the agent ignores PortMin and PortMax configurations and will
+    /// defer to UDPMux for incoming connections
+    pub udp_mux: Option<Arc<dyn UDPMux>>,
 
     /// A function that you can use in order to whitelist or blacklist the interfaces which are
     /// used to gather ICE candidates.

--- a/src/agent/agent_config.rs
+++ b/src/agent/agent_config.rs
@@ -2,8 +2,8 @@ use super::*;
 use crate::error::*;
 use crate::mdns::*;
 use crate::network_type::*;
-use crate::udp_mux::UDPMux;
 use crate::url::*;
+use crate::UDPNetwork;
 
 use util::vnet::net::*;
 
@@ -58,10 +58,9 @@ pub type InterfaceFilterFn = Box<dyn (Fn(&str) -> bool) + Send + Sync>;
 pub struct AgentConfig {
     pub urls: Vec<Url>,
 
-    /// This is optional. Leave it as 0 for the default UDP port allocation strategy.
-    pub port_min: u16,
-    /// This is optional. Leave it as 0 for the default UDP port allocation strategy.
-    pub port_max: u16,
+    /// Controls how the UDP network stack works.
+    /// See [`UDPNetwork`]
+    pub udp_network: UDPNetwork,
 
     /// It is used to perform connectivity checks. The values MUST be unguessable, with at least
     /// 128 bits of random number generator output used to generate the password, and at least 24
@@ -139,11 +138,6 @@ pub struct AgentConfig {
     /// Net is the our abstracted network interface for internal development purpose only
     /// (see (github.com/pion/transport/vnet)[github.com/pion/transport/vnet]).
     pub net: Option<Arc<Net>>,
-
-    /// UDPMux is used for multiplexing multiple incoming UDP connections on a single port
-    /// when this is set, the agent ignores PortMin and PortMax configurations and will
-    /// defer to UDPMux for incoming connections
-    pub udp_mux: Option<Arc<dyn UDPMux>>,
 
     /// A function that you can use in order to whitelist or blacklist the interfaces which are
     /// used to gather ICE candidates.

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -20,6 +20,7 @@ use crate::external_ip_mapper::*;
 use crate::mdns::*;
 use crate::network_type::*;
 use crate::state::*;
+use crate::udp_mux::UDPMux;
 use crate::url::*;
 use agent_config::*;
 use agent_internal::*;
@@ -107,6 +108,8 @@ pub struct Agent {
     pub(crate) candidate_types: Vec<CandidateType>,
     pub(crate) urls: Vec<Url>,
     pub(crate) network_types: Vec<NetworkType>,
+
+    pub(crate) udp_mux: Option<Arc<dyn UDPMux>>,
 
     pub(crate) gather_candidate_cancel: Option<GatherCandidateCancelFn>,
 }
@@ -210,6 +213,8 @@ impl Agent {
             network_types: config.network_types.clone(),
 
             gather_candidate_cancel: None, //TODO: add cancel
+
+            udp_mux: config.udp_mux,
         };
 
         agent

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -22,6 +22,7 @@ use crate::network_type::*;
 use crate::state::*;
 use crate::udp_mux::UDPMux;
 use crate::url::*;
+use crate::UDPNetwork;
 use agent_config::*;
 use agent_internal::*;
 use agent_stats::*;
@@ -94,8 +95,7 @@ struct ChanReceivers {
 pub struct Agent {
     pub(crate) internal: Arc<AgentInternal>,
 
-    pub(crate) port_min: u16,
-    pub(crate) port_max: u16,
+    pub(crate) udp_network: UDPNetwork,
     pub(crate) interface_filter: Arc<Option<InterfaceFilterFn>>,
     pub(crate) mdns_mode: MulticastDnsMode,
     pub(crate) mdns_name: String,
@@ -109,16 +109,19 @@ pub struct Agent {
     pub(crate) urls: Vec<Url>,
     pub(crate) network_types: Vec<NetworkType>,
 
-    pub(crate) udp_mux: Option<Arc<dyn UDPMux>>,
-
     pub(crate) gather_candidate_cancel: Option<GatherCandidateCancelFn>,
 }
 
 impl Agent {
     /// Creates a new Agent.
     pub async fn new(config: AgentConfig) -> Result<Self> {
-        if config.port_max < config.port_min {
-            return Err(Error::ErrPort);
+        match &config.udp_network {
+            crate::UDPNetwork::Ephemeral(ephemeral) => {
+                if ephemeral.port_max < ephemeral.port_min {
+                    return Err(Error::ErrPort);
+                }
+            }
+            crate::UDPNetwork::Muxed(_) => {}
         }
 
         let mut mdns_name = config.multicast_dns_host_name.clone();
@@ -198,8 +201,7 @@ impl Agent {
         };
 
         let agent = Self {
-            port_min: config.port_min,
-            port_max: config.port_max,
+            udp_network: config.udp_network,
             internal: Arc::new(ai),
             interface_filter: Arc::clone(&config.interface_filter),
             mdns_mode,
@@ -213,8 +215,6 @@ impl Agent {
             network_types: config.network_types.clone(),
 
             gather_candidate_cancel: None, //TODO: add cancel
-
-            udp_mux: config.udp_mux,
         };
 
         agent
@@ -342,6 +342,11 @@ impl Agent {
             gather_candidate_cancel();
         }
 
+        if let UDPNetwork::Muxed(ref udp_mux) = self.udp_network {
+            let (ufrag, _) = self.get_local_user_credentials().await;
+            udp_mux.remove_conn_by_frag(&ufrag).await;
+        }
+
         //FIXME: deadlock here
         self.internal.close().await
     }
@@ -450,11 +455,10 @@ impl Agent {
         //TODO: a.gatherCandidateCancel = cancel
 
         let params = GatherCandidatesInternalParams {
+            udp_network: self.udp_network.clone(),
             candidate_types: self.candidate_types.clone(),
             urls: self.urls.clone(),
             network_types: self.network_types.clone(),
-            port_max: self.port_max,
-            port_min: self.port_min,
             mdns_mode: self.mdns_mode,
             mdns_name: self.mdns_name.clone(),
             net: Arc::clone(&self.net),

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -344,7 +344,7 @@ impl Agent {
 
         if let UDPNetwork::Muxed(ref udp_mux) = self.udp_network {
             let (ufrag, _) = self.get_local_user_credentials().await;
-            udp_mux.remove_conn_by_frag(&ufrag).await;
+            udp_mux.remove_conn_by_ufrag(&ufrag).await;
         }
 
         //FIXME: deadlock here

--- a/src/error.rs
+++ b/src/error.rs
@@ -191,6 +191,8 @@ pub enum Error {
     ErrInvalidUrl,
     #[error("relative URL without a base")]
     ErrUrlParse,
+    #[error("Candidate IP could not be found")]
+    ErrCandidateIpNotFound,
 
     #[error("parse int: {0}")]
     ParseInt(#[from] ParseIntError),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod rand;
 pub mod state;
 pub mod stats;
 pub mod tcp_type;
+pub mod udp_mux;
 pub mod url;
 pub mod use_candidate;
 mod util;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 #![warn(rust_2018_idioms)]
 #![allow(dead_code)]
 
+use std::sync::Arc;
+
 pub mod agent;
 pub mod candidate;
 pub mod control;
@@ -17,5 +19,46 @@ pub mod udp_mux;
 pub mod url;
 pub mod use_candidate;
 mod util;
+
+#[derive(Default, Clone)]
+pub struct EphemeralUDP {
+    pub port_min: u16,
+    pub port_max: u16,
+}
+
+/// Configuration for the underlying UDP network stack.
+/// There are two ways to configure this Ephemeral and Muxed.
+///
+/// **Ephemeral mode**
+///
+/// In Ephemeral mode sockets are created and bound to random ports during ICE
+/// gathering. The ports to use can be restricted by setting [`EphemeralUDP::port_min`] and
+/// [`EphemeralEphemeralUDP::port_max`] in which case only ports in this range will be used.
+///
+/// **Muxed**
+///
+/// In muxed mode a single UDP socket is used and all connections are muxed over this single socket.
+///
+#[derive(Clone)]
+pub enum UDPNetwork {
+    Ephemeral(EphemeralUDP),
+    Muxed(Arc<dyn udp_mux::UDPMux + Send + Sync>),
+}
+
+impl Default for UDPNetwork {
+    fn default() -> Self {
+        Self::Ephemeral(Default::default())
+    }
+}
+
+impl UDPNetwork {
+    fn is_ephemeral(&self) -> bool {
+        matches!(self, Self::Ephemeral(_))
+    }
+
+    fn is_muxed(&self) -> bool {
+        matches!(self, Self::Muxed(_))
+    }
+}
 
 pub use error::Error;

--- a/src/udp_mux/mod.rs
+++ b/src/udp_mux/mod.rs
@@ -18,6 +18,9 @@ use tokio::sync::Mutex;
 mod udp_mux_conn;
 use udp_mux_conn::{UDPMuxConn, UDPMuxConnParams};
 
+#[cfg(test)]
+mod udp_mux_test;
+
 mod socket_addr_ext;
 
 use stun::{

--- a/src/udp_mux/mod.rs
+++ b/src/udp_mux/mod.rs
@@ -47,6 +47,12 @@ pub struct UDPMuxParams {
     udp_socket: UdpSocket,
 }
 
+impl UDPMuxParams {
+    pub fn new(udp_socket: UdpSocket) -> Self {
+        Self { udp_socket }
+    }
+}
+
 #[derive(Debug)]
 pub struct UDPMuxDefault {
     /// The params this instance is configured with.
@@ -64,7 +70,7 @@ pub struct UDPMuxDefault {
 }
 
 impl UDPMuxDefault {
-    fn new(params: UDPMuxParams) -> Arc<Self> {
+    pub fn new(params: UDPMuxParams) -> Arc<Self> {
         let mux = Arc::new(Self {
             params,
             conns: Mutex::default(),
@@ -78,7 +84,7 @@ impl UDPMuxDefault {
         mux
     }
 
-    fn is_closed(&self) -> bool {
+    pub fn is_closed(&self) -> bool {
         self.closed.load(Ordering::SeqCst)
     }
 

--- a/src/udp_mux/mod.rs
+++ b/src/udp_mux/mod.rs
@@ -124,11 +124,7 @@ impl UDPMuxDefault {
         log::debug!("Registered {} for {}", addr, key);
     }
 
-    async fn conn_from_stun_message(
-        self: Arc<Self>,
-        buffer: &[u8],
-        addr: &SocketAddr,
-    ) -> Option<UDPMuxConn> {
+    async fn conn_from_stun_message(&self, buffer: &[u8], addr: &SocketAddr) -> Option<UDPMuxConn> {
         let (result, message) = {
             let mut m = STUNMessage::new();
 

--- a/src/udp_mux/mod.rs
+++ b/src/udp_mux/mod.rs
@@ -1,0 +1,312 @@
+use std::{
+    collections::HashMap,
+    io::ErrorKind,
+    net::SocketAddr,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        Arc, RwLock,
+    },
+};
+
+use util::{Conn, Error};
+
+use async_trait::async_trait;
+
+use tokio::net::UdpSocket;
+use tokio::sync::Mutex;
+
+mod udp_mux_conn;
+use udp_mux_conn::{UDPMuxConn, UDPMuxConnParams};
+
+mod socket_addr_ext;
+
+use stun::{
+    attributes::ATTR_USERNAME,
+    message::{is_message as is_stun_message, Message as STUNMessage},
+};
+
+use crate::candidate::RECEIVE_MTU;
+
+#[async_trait]
+trait UDPMux {
+    /// Close the muxing.
+    async fn close(&self);
+
+    /// Get the underlying connection for a given ufrag.
+    async fn get_conn(self: &Arc<Self>, ufrag: &str) -> Result<Arc<dyn Conn + Send + Sync>, Error>;
+
+    /// Remove the underlying connection for a given ufrag.
+    async fn remove_conn_by_frag(self: &Arc<Self>, ufrag: &str);
+}
+
+#[derive(Debug)]
+struct UDPMuxParams {
+    udp_socket: UdpSocket,
+}
+
+#[derive(Debug)]
+struct UDPMuxDefault {
+    /// The params this instance is configured with.
+    /// Contains the underlying UDP socket in use
+    params: UDPMuxParams,
+
+    /// Maps from ufrag to the underlying connection.
+    conns: Mutex<HashMap<String, UDPMuxConn>>,
+
+    /// Maps from ip address to the underlying connection.
+    address_map: RwLock<HashMap<SocketAddr, UDPMuxConn>>,
+
+    /// Whether this connection has been closed
+    closed: AtomicBool,
+}
+
+impl UDPMuxDefault {
+    fn new(params: UDPMuxParams) -> Arc<Self> {
+        let mux = Arc::new(Self {
+            params,
+            conns: Mutex::default(),
+            address_map: RwLock::default(),
+            closed: AtomicBool::new(false),
+        });
+
+        let cloned_mux = Arc::clone(&mux);
+        cloned_mux.start_conn_worker();
+
+        mux
+    }
+
+    fn is_closed(&self) -> bool {
+        self.closed.load(Ordering::SeqCst)
+    }
+
+    async fn send_to(&self, buf: &[u8], target: &SocketAddr) -> Result<usize, Error> {
+        self.params
+            .udp_socket
+            .send_to(&buf, target)
+            .await
+            .map_err(Into::into)
+    }
+
+    /// Create a muxed connection for a given ufrag.
+    async fn create_muxed_conn(self: &Arc<Self>, ufrag: &str) -> UDPMuxConn {
+        let local_addr = self.params.udp_socket.local_addr().ok();
+
+        let params = UDPMuxConnParams {
+            local_addr,
+            key: ufrag.into(),
+            udp_mux: Arc::clone(self),
+        };
+
+        UDPMuxConn::new(params)
+    }
+
+    fn register_conn_for_address(&self, conn: &UDPMuxConn, addr: SocketAddr) {
+        if self.is_closed() {
+            return;
+        }
+
+        let key = conn.key().clone();
+        {
+            let mut addresses = self
+                .address_map
+                .write()
+                .expect("Failed to obtain write lock");
+
+            addresses
+                .entry(addr.clone())
+                .and_modify(|e| {
+                    e.remove_address(&addr);
+                    *e = conn.clone()
+                })
+                .or_insert(conn.clone());
+        }
+
+        log::debug!("Registered {} for {}", addr, key);
+    }
+
+    async fn conn_from_stun_message(
+        self: Arc<Self>,
+        buffer: &[u8],
+        addr: &SocketAddr,
+    ) -> Option<UDPMuxConn> {
+        let (result, message) = {
+            let mut m = STUNMessage::new();
+
+            (m.unmarshal_binary(&buffer), m)
+        };
+
+        match result {
+            Err(err) => {
+                log::warn!("Failed to handle decode ICE from {}: {}", addr, err);
+                return None;
+            }
+            Ok(_) => {
+                let (attr, found) = message.attributes.get(ATTR_USERNAME);
+                if !found {
+                    log::warn!("No username attribute in STUN message from {}", &addr);
+                    return None;
+                }
+
+                let s = match String::from_utf8(attr.value) {
+                    // Per the RFC this shouldn't happen
+                    // https://datatracker.ietf.org/doc/html/rfc5389#section-15.3
+                    Err(err) => {
+                        log::warn!(
+                            "Failed to decode USERNAME from STUN message as UTF-8: {}",
+                            err
+                        );
+                        return None;
+                    }
+                    Ok(s) => s,
+                };
+
+                let conns = self.conns.lock().await;
+                let conn = s
+                    .split(":")
+                    .next()
+                    .and_then(|ufrag| conns.get(ufrag))
+                    .map(Clone::clone);
+
+                conn
+            }
+        }
+    }
+
+    fn start_conn_worker(self: Arc<Self>) {
+        tokio::spawn(async move {
+            let mut buffer = [0u8; RECEIVE_MTU];
+
+            loop {
+                let loop_self = Arc::clone(&self);
+                let socket = &loop_self.params.udp_socket;
+
+                if loop_self.is_closed() {
+                    break;
+                }
+
+                match socket.recv_from(&mut buffer).await {
+                    Ok((len, addr)) => {
+                        // Find connection based on previously having seen this source address
+                        let conn = {
+                            let address_map = loop_self
+                                .address_map
+                                .read()
+                                .expect("Failed to acquire read lock");
+                            address_map.get(&addr).map(Clone::clone)
+                        };
+
+                        let conn = match conn {
+                            // If we couldn't find the connection based on source address, see if
+                            // this is a STUN mesage and if so if we can find the connection based on ufrag.
+                            None if is_stun_message(&buffer) => {
+                                loop_self.conn_from_stun_message(&buffer, &addr).await
+                            }
+                            s @ Some(_) => s,
+                            _ => None,
+                        };
+
+                        match conn {
+                            None => {
+                                log::trace!("Dropping packet from {}", &addr);
+                            }
+                            Some(conn) => {
+                                if let Err(err) = conn.write_packet(&buffer[..len], addr).await {
+                                    log::error!("Failed to write packet: {}", err);
+                                }
+                            }
+                        }
+                    }
+                    Err(err) if err.kind() == ErrorKind::TimedOut => continue,
+                    Err(err) => {
+                        log::error!("Could not read udp packet: {}", err);
+                        break;
+                    }
+                };
+            }
+        });
+    }
+}
+
+#[async_trait]
+impl UDPMux for UDPMuxDefault {
+    async fn close(&self) {
+        if self.is_closed() {
+            return;
+        }
+
+        self.closed.store(true, Ordering::SeqCst);
+
+        let old_conns = {
+            let mut conns = self.conns.lock().await;
+
+            std::mem::replace(&mut (*conns), Default::default())
+        };
+
+        // NOTE: We don't wait for these closure to complete
+        for (_, conn) in old_conns.into_iter() {
+            conn.close();
+        }
+
+        {
+            let mut address_map = self
+                .address_map
+                .write()
+                .expect("Failed to obtain address_map lock");
+
+            // NOTE: This is important, we need to drop all instances of `UDPMuxConn` to
+            // avoid a retain cycle due to the use of [`std::sync::Arc`] on both sides.
+            let _ = std::mem::replace(&mut (*address_map), Default::default());
+        }
+    }
+
+    async fn get_conn(self: &Arc<Self>, ufrag: &str) -> Result<Arc<dyn Conn + Send + Sync>, Error> {
+        if self.is_closed() {
+            return Err(Error::ErrUseClosedNetworkConn);
+        }
+
+        {
+            let mut conns = self.conns.lock().await;
+            if let Some(conn) = conns.get(ufrag) {
+                // UDPMuxConn uses `Arc` internally so it's cheap to clone, but because
+                // we implement `Conn` we need to further wrap it in an `Arc` here.
+                return Ok(Arc::new(conn.clone()) as Arc<dyn Conn + Send + Sync>);
+            }
+
+            let muxed_conn = self.create_muxed_conn(ufrag.into()).await;
+            let mut close_rx = muxed_conn.close_rx();
+            let cloned_self = Arc::clone(&self);
+            let cloned_ufrag = ufrag.to_string();
+            tokio::spawn(async move {
+                let _ = close_rx.changed().await;
+
+                // Arc needed
+                cloned_self.remove_conn_by_frag(&cloned_ufrag).await;
+            });
+
+            conns.insert(ufrag.into(), muxed_conn.clone());
+
+            Ok(Arc::new(muxed_conn) as Arc<dyn Conn + Send + Sync>)
+        }
+    }
+
+    async fn remove_conn_by_frag(self: &Arc<Self>, ufrag: &str) {
+        // Pion's ice implementation has both `RemoveConnByFrag` and `RemoveConn`, but since `conns`
+        // is keyed on `ufrag` their implementation is equivalent.
+
+        let removed_conn = {
+            let mut conns = self.conns.lock().await;
+            conns.remove(ufrag)
+        };
+
+        if let Some(conn) = removed_conn {
+            let mut address_map = self
+                .address_map
+                .write()
+                .expect("Failed to obtain write lock for address_map");
+
+            for address in conn.get_addresses() {
+                address_map.remove(&address);
+            }
+        }
+    }
+}

--- a/src/udp_mux/mod.rs
+++ b/src/udp_mux/mod.rs
@@ -28,24 +28,24 @@ use stun::{
 use crate::candidate::RECEIVE_MTU;
 
 #[async_trait]
-trait UDPMux {
+pub trait UDPMux {
     /// Close the muxing.
     async fn close(&self);
 
     /// Get the underlying connection for a given ufrag.
-    async fn get_conn(self: &Arc<Self>, ufrag: &str) -> Result<Arc<dyn Conn + Send + Sync>, Error>;
+    async fn get_conn(self: Arc<Self>, ufrag: &str) -> Result<Arc<dyn Conn + Send + Sync>, Error>;
 
     /// Remove the underlying connection for a given ufrag.
-    async fn remove_conn_by_frag(self: &Arc<Self>, ufrag: &str);
+    async fn remove_conn_by_frag(&self, ufrag: &str);
 }
 
 #[derive(Debug)]
-struct UDPMuxParams {
+pub struct UDPMuxParams {
     udp_socket: UdpSocket,
 }
 
 #[derive(Debug)]
-struct UDPMuxDefault {
+pub struct UDPMuxDefault {
     /// The params this instance is configured with.
     /// Contains the underlying UDP socket in use
     params: UDPMuxParams,
@@ -259,7 +259,7 @@ impl UDPMux for UDPMuxDefault {
         }
     }
 
-    async fn get_conn(self: &Arc<Self>, ufrag: &str) -> Result<Arc<dyn Conn + Send + Sync>, Error> {
+    async fn get_conn(self: Arc<Self>, ufrag: &str) -> Result<Arc<dyn Conn + Send + Sync>, Error> {
         if self.is_closed() {
             return Err(Error::ErrUseClosedNetworkConn);
         }
@@ -289,7 +289,7 @@ impl UDPMux for UDPMuxDefault {
         }
     }
 
-    async fn remove_conn_by_frag(self: &Arc<Self>, ufrag: &str) {
+    async fn remove_conn_by_frag(&self, ufrag: &str) {
         // Pion's ice implementation has both `RemoveConnByFrag` and `RemoveConn`, but since `conns`
         // is keyed on `ufrag` their implementation is equivalent.
 

--- a/src/udp_mux/socket_addr_ext.rs
+++ b/src/udp_mux/socket_addr_ext.rs
@@ -106,7 +106,7 @@ impl SocketAddrExt for SocketAddr {
                     ip, port, flowinfo, scope_id,
                 )))
             }
-            _ => return Err(Error::ErrFailedToParseIpaddr),
+            _ => Err(Error::ErrFailedToParseIpaddr),
         }
     }
 }

--- a/src/udp_mux/socket_addr_ext.rs
+++ b/src/udp_mux/socket_addr_ext.rs
@@ -197,4 +197,49 @@ mod test {
 
         assert_eq!(decoded, Ok(ip));
     }
+
+    #[test]
+    fn test_encode_ipv4_with_short_buffer() {
+        let mut buffer = vec![0u8; IPV4_ADDRESS_SIZE - 1];
+        let ip = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::from([56, 128, 35, 5]), 0x1234));
+
+        let result = ip.encode(&mut buffer);
+
+        assert_eq!(result, Err(Error::ErrBufferShort));
+    }
+
+    #[test]
+    fn test_encode_ipv6_with_short_buffer() {
+        let mut buffer = vec![0u8; MAX_ADDR_SIZE - 1];
+        let ip = SocketAddr::V6(SocketAddrV6::new(
+            Ipv6Addr::from([
+                92, 114, 235, 3, 244, 64, 38, 111, 20, 100, 199, 241, 19, 174, 220, 123,
+            ]),
+            0x1234,
+            0x12345678,
+            0x87654321,
+        ));
+
+        let result = ip.encode(&mut buffer);
+
+        assert_eq!(result, Err(Error::ErrBufferShort));
+    }
+
+    #[test]
+    fn test_decode_ipv4_with_short_buffer() {
+        let buffer = vec![IPV4_MARKER, 0];
+
+        let result = SocketAddr::decode(&buffer);
+
+        assert_eq!(result, Err(Error::ErrBufferShort));
+    }
+
+    #[test]
+    fn test_decode_ipv6_with_short_buffer() {
+        let buffer = vec![IPV6_MARKER, 0];
+
+        let result = SocketAddr::decode(&buffer);
+
+        assert_eq!(result, Err(Error::ErrBufferShort));
+    }
 }

--- a/src/udp_mux/socket_addr_ext.rs
+++ b/src/udp_mux/socket_addr_ext.rs
@@ -1,0 +1,193 @@
+use std::array::TryFromSliceError;
+use std::convert::TryInto;
+use std::net::SocketAddr;
+
+use util::Error;
+
+pub(super) trait SocketAddrExt {
+    ///Encode a representation of `self` into the buffer and return the length of this encoded
+    ///version.
+    ///
+    /// The buffer needs to be at least 27 bytes in length.
+    fn encode(&self, buffer: &mut [u8]) -> Result<usize, Error>;
+
+    /// Decode a `SocketAddr` from a buffer. The encoding should have previously been done with
+    /// [`SocketAddrExt::encode`].
+    fn decode(buffer: &[u8]) -> Result<SocketAddr, Error>;
+}
+
+const IPV4_MARKER: u8 = 4;
+const IPV6_MARKER: u8 = 6;
+pub(super) const MAX_ADDR_SIZE: usize = 27;
+
+impl SocketAddrExt for SocketAddr {
+    fn encode(&self, buffer: &mut [u8]) -> Result<usize, Error> {
+        use std::net::SocketAddr::*;
+
+        if buffer.len() < MAX_ADDR_SIZE {
+            return Err(Error::ErrBufferShort);
+        }
+
+        match self {
+            V4(addr) => {
+                let marker = IPV4_MARKER;
+                let ip: [u8; 4] = addr.ip().octets();
+                let port: u16 = addr.port();
+
+                buffer[0] = marker;
+                buffer[1..5].copy_from_slice(&ip);
+                buffer[5..7].copy_from_slice(&port.to_le_bytes());
+
+                Ok(7)
+            }
+            V6(addr) => {
+                let marker = IPV6_MARKER;
+                let ip: [u8; 16] = addr.ip().octets();
+                let port: u16 = addr.port();
+                let flowinfo = addr.flowinfo();
+                let scope_id = addr.scope_id();
+
+                buffer[0] = marker;
+                buffer[1..17].copy_from_slice(&ip);
+                buffer[17..19].copy_from_slice(&port.to_le_bytes());
+                buffer[19..23].copy_from_slice(&flowinfo.to_le_bytes());
+                buffer[23..27].copy_from_slice(&scope_id.to_le_bytes());
+
+                Ok(MAX_ADDR_SIZE)
+            }
+        }
+    }
+
+    fn decode(buffer: &[u8]) -> Result<SocketAddr, Error> {
+        use std::net::*;
+
+        if buffer.len() < MAX_ADDR_SIZE {
+            return Err(Error::ErrBufferShort);
+        }
+
+        match buffer[0] {
+            IPV4_MARKER => {
+                let ip_parts = &buffer[1..5];
+                let port = match &buffer[5..7].try_into() {
+                    Err(_) => return Err(Error::ErrFailedToParseIpaddr),
+                    Ok(input) => u16::from_le_bytes(*input),
+                };
+
+                let ip = Ipv4Addr::new(ip_parts[0], ip_parts[1], ip_parts[2], ip_parts[3]);
+
+                Ok(SocketAddr::V4(SocketAddrV4::new(ip, port)))
+            }
+            IPV6_MARKER => {
+                // Just to help the type system infer correctly
+                fn helper(b: &[u8]) -> Result<&[u8; 16], TryFromSliceError> {
+                    b.try_into()
+                }
+
+                let ip = match helper(&buffer[1..17]) {
+                    Err(_) => return Err(Error::ErrFailedToParseIpaddr),
+                    Ok(input) => Ipv6Addr::from(*input),
+                };
+                let port = match &buffer[17..19].try_into() {
+                    Err(_) => return Err(Error::ErrFailedToParseIpaddr),
+                    Ok(input) => u16::from_le_bytes(*input),
+                };
+
+                let flowinfo = match &buffer[19..23].try_into() {
+                    Err(_) => return Err(Error::ErrFailedToParseIpaddr),
+                    Ok(input) => u32::from_le_bytes(*input),
+                };
+
+                let scope_id = match &buffer[23..27].try_into() {
+                    Err(_) => return Err(Error::ErrFailedToParseIpaddr),
+                    Ok(input) => u32::from_le_bytes(*input),
+                };
+
+                Ok(SocketAddr::V6(SocketAddrV6::new(
+                    ip, port, flowinfo, scope_id,
+                )))
+            }
+            _ => return Err(Error::ErrFailedToParseIpaddr),
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use std::net::*;
+
+    #[test]
+    fn test_ipv4() {
+        let ip = SocketAddr::V4(SocketAddrV4::new(Ipv4Addr::from([56, 128, 35, 5]), 0x1234));
+
+        let mut buffer = [0_u8; MAX_ADDR_SIZE];
+        let encoded_len = ip.encode(&mut buffer);
+
+        assert_eq!(encoded_len, Ok(7));
+        assert_eq!(
+            &buffer[0..7],
+            &[IPV4_MARKER, 56, 128, 35, 5, 0x34, 0x12][..]
+        );
+
+        let decoded = SocketAddr::decode(&buffer);
+
+        assert_eq!(decoded, Ok(ip));
+    }
+
+    #[test]
+    fn test_ipv6() {
+        let ip = SocketAddr::V6(SocketAddrV6::new(
+            Ipv6Addr::from([
+                92, 114, 235, 3, 244, 64, 38, 111, 20, 100, 199, 241, 19, 174, 220, 123,
+            ]),
+            0x1234,
+            0x12345678,
+            0x87654321,
+        ));
+
+        let mut buffer = [0_u8; MAX_ADDR_SIZE];
+        let encoded_len = ip.encode(&mut buffer);
+
+        assert_eq!(encoded_len, Ok(27));
+        assert_eq!(
+            &buffer[0..27],
+            &[
+                IPV6_MARKER, // marker
+                // Start of ipv6 address
+                92,
+                114,
+                235,
+                3,
+                244,
+                64,
+                38,
+                111,
+                20,
+                100,
+                199,
+                241,
+                19,
+                174,
+                220,
+                123,
+                // LE port
+                0x34,
+                0x12,
+                // LE flowinfo
+                0x78,
+                0x56,
+                0x34,
+                0x12,
+                // LE scope_id
+                0x21,
+                0x43,
+                0x65,
+                0x87,
+            ][..]
+        );
+
+        let decoded = SocketAddr::decode(&buffer);
+
+        assert_eq!(decoded, Ok(ip));
+    }
+}

--- a/src/udp_mux/udp_mux_conn.rs
+++ b/src/udp_mux/udp_mux_conn.rs
@@ -63,15 +63,15 @@ impl UDPMuxConnInner {
             return Err(Error::ErrBufferShort);
         }
 
-        let data_len: usize = *(&buffer[..2]
+        let data_len: usize = buffer[..2]
             .try_into()
-            .map(|bytes| u16::from_le_bytes(bytes))
+            .map(u16::from_le_bytes)
             .map(From::from)
-            .unwrap());
+            .unwrap();
         offset += 2;
 
-        let total = usize::from(2 + data_len + 2 + 7);
-        if usize::from(data_len) > buf.len() || total > len {
+        let total = 2 + data_len + 2 + 7;
+        if data_len > buf.len() || total > len {
             return Err(Error::ErrBufferShort);
         }
 
@@ -84,7 +84,7 @@ impl UDPMuxConnInner {
     }
 
     async fn send_to(&self, buf: &[u8], target: &SocketAddr) -> ConnResult<usize> {
-        self.params.udp_mux.send_to(&buf, target).await
+        self.params.udp_mux.send_to(buf, target).await
     }
 
     fn is_closed(&self) -> bool {
@@ -137,7 +137,7 @@ impl UDPMuxConnInner {
     pub(super) fn add_address(self: &Arc<Self>, addr: SocketAddr) {
         {
             let mut addresses = self.addresses.lock().expect("Failed to obtain lock");
-            addresses.insert(addr.clone());
+            addresses.insert(addr);
         }
     }
 
@@ -282,10 +282,10 @@ impl Conn for UDPMuxConn {
         }
 
         if !self.contains_address(&target) {
-            self.add_address(target.clone());
+            self.add_address(target);
         }
 
-        self.inner.send_to(&buf, &target).await
+        self.inner.send_to(buf, &target).await
     }
 
     async fn local_addr(&self) -> ConnResult<SocketAddr> {

--- a/src/udp_mux/udp_mux_conn.rs
+++ b/src/udp_mux/udp_mux_conn.rs
@@ -77,7 +77,7 @@ impl UDPMuxConnInner {
             return Err(Error::ErrBufferShort);
         }
 
-        buf.copy_from_slice(&buffer[offset..offset + data_len]);
+        buf[..data_len].copy_from_slice(&buffer[offset..offset + data_len]);
         offset += data_len;
 
         let address_len: usize = buffer[offset..offset + 2]
@@ -132,7 +132,7 @@ impl UDPMuxConnInner {
         }
     }
 
-    fn remote_addr(&self) -> Option<SocketAddr> {
+    fn local_addr(&self) -> Option<SocketAddr> {
         self.params.local_addr
     }
 
@@ -298,11 +298,13 @@ impl Conn for UDPMuxConn {
     }
 
     async fn local_addr(&self) -> ConnResult<SocketAddr> {
-        Err(io::Error::new(io::ErrorKind::AddrNotAvailable, "Addr Not Available").into())
+        self.inner.local_addr().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::AddrNotAvailable, "Addr Not Available").into()
+        })
     }
 
     async fn remote_addr(&self) -> Option<SocketAddr> {
-        self.inner.remote_addr()
+        None
     }
     async fn close(&self) -> ConnResult<()> {
         self.inner.close();

--- a/src/udp_mux/udp_mux_conn.rs
+++ b/src/udp_mux/udp_mux_conn.rs
@@ -1,0 +1,303 @@
+use std::convert::TryInto;
+use std::{
+    collections::HashSet,
+    io,
+    net::SocketAddr,
+    sync::{Arc, Mutex},
+};
+
+use async_trait::async_trait;
+use tokio::sync::watch;
+
+use util::{Buffer, Conn, Error};
+
+use super::socket_addr_ext::{SocketAddrExt, MAX_ADDR_SIZE};
+use super::{UDPMuxDefault, RECEIVE_MTU};
+
+#[inline(always)]
+/// Create a buffer of appropriate size to fit both a packet with max RECEIVE_MTU and the
+/// additional metadata used for muxing.
+fn make_buffer() -> Vec<u8> {
+    vec![0u8; RECEIVE_MTU + MAX_ADDR_SIZE]
+}
+
+#[derive(Debug)]
+pub(crate) struct UDPMuxConnParams {
+    pub(super) local_addr: Option<SocketAddr>,
+
+    pub(super) key: String,
+
+    // NOTE: This Arc exists in both directions which is liable to cause a retain cycle. This is
+    // accounted for in [`UDPMuxDefault::close`], which makes sure to drop all Arcs referencing any
+    // `UDPMuxConn`.
+    pub(super) udp_mux: Arc<UDPMuxDefault>,
+}
+
+#[derive(Debug)]
+struct UDPMuxConnInner {
+    pub(super) params: UDPMuxConnParams,
+
+    /// Close Sender. We'll send a value on this channel when we close
+    closed_watch_tx: Mutex<Option<watch::Sender<bool>>>,
+
+    /// Remote addresses we've seen on this connection.
+    addresses: Mutex<HashSet<SocketAddr>>,
+
+    buffer: Buffer,
+}
+
+impl UDPMuxConnInner {
+    // Sending/Recieving
+    async fn recv_from(&self, buf: &mut [u8]) -> ConnResult<(usize, SocketAddr)> {
+        // NOTE: Pion/ice uses Sync.Pool to optimise this.
+        let mut buffer = make_buffer();
+        let mut offset = 0;
+
+        let len = self.buffer.read(&mut buffer, None).await?;
+        // We always have at least.
+        //
+        // * 2 bytes for data len
+        // * 2 bytes for addr len
+        // * 7 bytes for an Ipv4 addr
+        if len < 11 {
+            return Err(Error::ErrBufferShort);
+        }
+
+        let data_len: usize = *(&buffer[..2]
+            .try_into()
+            .map(|bytes| u16::from_le_bytes(bytes))
+            .map(From::from)
+            .unwrap());
+        offset += 2;
+
+        let total = usize::from(2 + data_len + 2 + 7);
+        if usize::from(data_len) > buf.len() || total > len {
+            return Err(Error::ErrBufferShort);
+        }
+
+        buf.copy_from_slice(&buffer[offset..offset + data_len]);
+        offset += data_len;
+
+        let addr = SocketAddr::decode(&buffer[offset..])?;
+
+        Ok((data_len, addr))
+    }
+
+    async fn send_to(&self, buf: &[u8], target: &SocketAddr) -> ConnResult<usize> {
+        self.params.udp_mux.send_to(&buf, target).await
+    }
+
+    fn is_closed(&self) -> bool {
+        self.closed_watch_tx
+            .lock()
+            .expect("Failed to acquire lock")
+            .is_none()
+    }
+
+    fn close(self: &Arc<Self>) {
+        // TODO: Handle lock error/switch to tokio's Mutex
+        let mut closed_tx = self
+            .closed_watch_tx
+            .lock()
+            .expect("Failed to acquire lock.");
+
+        if let Some(tx) = closed_tx.take() {
+            let _ = tx.send(true);
+            drop(closed_tx);
+
+            let cloned_self = Arc::clone(self);
+
+            {
+                let mut addresses = self
+                    .addresses
+                    .lock()
+                    .expect("Failed to obtain addresses lock");
+                *addresses = Default::default();
+            }
+
+            // NOTE: Alternatively we could wait on the buffer closing here so that
+            // our caller can wait for things to fully settle down
+            tokio::spawn(async move {
+                cloned_self.buffer.close().await;
+            });
+        }
+    }
+
+    fn remote_addr(&self) -> Option<SocketAddr> {
+        self.params.local_addr
+    }
+
+    // Address related methods
+    pub(super) fn get_addresses(&self) -> Vec<SocketAddr> {
+        let addresses = self.addresses.lock().expect("Failed to obtain lock");
+
+        addresses.iter().cloned().collect()
+    }
+
+    pub(super) fn add_address(self: &Arc<Self>, addr: SocketAddr) {
+        {
+            let mut addresses = self.addresses.lock().expect("Failed to obtain lock");
+            addresses.insert(addr.clone());
+        }
+    }
+
+    pub(super) fn remove_address(&self, addr: &SocketAddr) {
+        {
+            let mut addresses = self.addresses.lock().expect("Failed to obtain lock");
+            addresses.remove(addr);
+        }
+    }
+
+    pub(super) fn contains_address(&self, addr: &SocketAddr) -> bool {
+        let addresses = self.addresses.lock().expect("Failed to obtain lock");
+
+        addresses.contains(addr)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct UDPMuxConn {
+    /// Close Receiver. A copy of this can be obtained via [`close_tx`].
+    closed_watch_rx: watch::Receiver<bool>,
+
+    inner: Arc<UDPMuxConnInner>,
+}
+
+impl Clone for UDPMuxConn {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+            closed_watch_rx: self.closed_watch_rx.clone(),
+        }
+    }
+}
+
+impl UDPMuxConn {
+    pub(crate) fn new(params: UDPMuxConnParams) -> Self {
+        let (closed_watch_tx, closed_watch_rx) = watch::channel(false);
+
+        Self {
+            closed_watch_rx,
+            inner: Arc::new(UDPMuxConnInner {
+                params,
+                closed_watch_tx: Mutex::new(Some(closed_watch_tx)),
+                addresses: Default::default(),
+                buffer: Buffer::new(0, 0),
+            }),
+        }
+    }
+
+    pub(crate) fn key(&self) -> &str {
+        &self.inner.params.key
+    }
+
+    pub(crate) async fn write_packet(&self, data: &[u8], addr: SocketAddr) -> ConnResult<()> {
+        // NOTE: Pion/ice uses Sync.Pool to optimise this.
+        let mut buffer = make_buffer();
+        let mut offset = 0;
+
+        if data.len() + MAX_ADDR_SIZE >= RECEIVE_MTU + MAX_ADDR_SIZE {
+            return Err(Error::ErrBufferShort);
+        }
+
+        // Format of buffer: | data len(2) | data bytes(dn) | addr len(2) | addr bytes(an) |
+        // Where the number in parenthesis indicate the number of bytes used
+        // `dn` and `an` are the length in bytes of data and addr respectively.
+
+        // SAFETY: `data.len()` is at most RECEIVE_MTU(8192) - MAX_ADDR_SIZE(512)
+        buffer[0..2].copy_from_slice(&(data.len() as u16).to_le_bytes()[..]);
+        offset += 2;
+
+        buffer[offset..].copy_from_slice(data);
+        offset += data.len();
+
+        let len = addr.encode(&mut buffer[offset + 2..])?;
+        buffer[offset..offset + 2].copy_from_slice(&(len as u16).to_le_bytes()[..]);
+        offset += 2 + len;
+
+        self.inner.buffer.write(&buffer[..offset]).await?;
+
+        Ok(())
+    }
+
+    pub(crate) fn is_closed(&self) -> bool {
+        self.inner.is_closed()
+    }
+
+    /// Get a copy of the close [`tokio::sync::watch::Receiver`] that fires when this
+    /// connection is closed.
+    pub(crate) fn close_rx(&self) -> watch::Receiver<bool> {
+        self.closed_watch_rx.clone()
+    }
+
+    /// Close this connection
+    pub(crate) fn close(&self) {
+        self.inner.close();
+    }
+
+    pub(super) fn get_addresses(&self) -> Vec<SocketAddr> {
+        self.inner.get_addresses()
+    }
+
+    pub(super) fn add_address(&self, addr: SocketAddr) {
+        self.inner.add_address(addr);
+        self.inner
+            .params
+            .udp_mux
+            .register_conn_for_address(self, addr);
+    }
+
+    pub(super) fn remove_address(&self, addr: &SocketAddr) {
+        self.inner.remove_address(addr)
+    }
+
+    pub(super) fn contains_address(&self, addr: &SocketAddr) -> bool {
+        self.inner.contains_address(addr)
+    }
+}
+
+type ConnResult<T> = Result<T, util::Error>;
+
+#[async_trait]
+impl Conn for UDPMuxConn {
+    async fn connect(&self, _addr: SocketAddr) -> ConnResult<()> {
+        Err(io::Error::new(io::ErrorKind::Other, "Not applicable").into())
+    }
+
+    async fn recv(&self, _buf: &mut [u8]) -> ConnResult<usize> {
+        Err(io::Error::new(io::ErrorKind::Other, "Not applicable").into())
+    }
+
+    async fn recv_from(&self, buf: &mut [u8]) -> ConnResult<(usize, SocketAddr)> {
+        self.inner.recv_from(buf).await
+    }
+
+    async fn send(&self, _buf: &[u8]) -> ConnResult<usize> {
+        Err(io::Error::new(io::ErrorKind::Other, "Not applicable").into())
+    }
+
+    async fn send_to(&self, buf: &[u8], target: SocketAddr) -> ConnResult<usize> {
+        if self.is_closed() {
+            return Err(Error::ErrUseClosedNetworkConn);
+        }
+
+        if !self.contains_address(&target) {
+            self.add_address(target.clone());
+        }
+
+        self.inner.send_to(&buf, &target).await
+    }
+
+    async fn local_addr(&self) -> ConnResult<SocketAddr> {
+        Err(io::Error::new(io::ErrorKind::AddrNotAvailable, "Addr Not Available").into())
+    }
+
+    async fn remote_addr(&self) -> Option<SocketAddr> {
+        self.inner.remote_addr()
+    }
+    async fn close(&self) -> ConnResult<()> {
+        self.inner.close();
+
+        Ok(())
+    }
+}

--- a/src/udp_mux/udp_mux_conn.rs
+++ b/src/udp_mux/udp_mux_conn.rs
@@ -94,7 +94,6 @@ impl UDPMuxConnInner {
     }
 
     fn close(self: &Arc<Self>) {
-        // TODO: Handle lock error/switch to tokio's Mutex
         let mut closed_tx = self.closed_watch_tx.lock();
 
         if let Some(tx) = closed_tx.take() {

--- a/src/udp_mux/udp_mux_test.rs
+++ b/src/udp_mux/udp_mux_test.rs
@@ -1,5 +1,6 @@
 use std::convert::TryInto;
 use std::io;
+use std::net::Ipv6Addr;
 use std::time::Duration;
 
 use super::*;
@@ -55,7 +56,7 @@ async fn test_udp_mux() -> Result<()> {
     //     })
     //     .init();
 
-    let udp_socket = UdpSocket::bind("[::]:0").await?;
+    let udp_socket = UdpSocket::bind((Ipv6Addr::UNSPECIFIED, 0)).await?;
     let addr = udp_socket.local_addr()?;
     log::info!("Listening on {}", addr);
 

--- a/src/udp_mux/udp_mux_test.rs
+++ b/src/udp_mux/udp_mux_test.rs
@@ -1,6 +1,6 @@
 use std::convert::TryInto;
 use std::io;
-use std::net::Ipv6Addr;
+use std::net::Ipv4Addr;
 use std::time::Duration;
 
 use super::*;
@@ -56,7 +56,7 @@ async fn test_udp_mux() -> Result<()> {
     //     })
     //     .init();
 
-    let udp_socket = UdpSocket::bind((Ipv6Addr::UNSPECIFIED, 0)).await?;
+    let udp_socket = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0)).await?;
     let addr = udp_socket.local_addr()?;
     log::info!("Listening on {}", addr);
 
@@ -85,17 +85,17 @@ async fn test_udp_mux() -> Result<()> {
 
     #[cfg(all(unix, target_pointer_width = "64"))]
     {
-        let udp_mux_dyn_3 = Arc::clone(&udp_mux_dyn);
-        let h3 = tokio::spawn(async move {
-            timeout(
-                TIMEOUT,
-                test_mux_connection(Arc::clone(&udp_mux_dyn_3), "ufrag3", addr, Network::Ipv6),
-            )
-            .await
-        });
+        // let udp_mux_dyn_3 = Arc::clone(&udp_mux_dyn);
+        // let h3 = tokio::spawn(async move {
+        //     timeout(
+        //         TIMEOUT,
+        //         test_mux_connection(Arc::clone(&udp_mux_dyn_3), "ufrag3", addr, Network::Ipv6),
+        //     )
+        //     .await
+        // });
 
-        let (r1, r2, r3) = tokio::join!(h1, h2, h3);
-        all_results = [r1, r2, r3];
+        let (r1, r2) = tokio::join!(h1, h2);
+        all_results = [r1, r2];
     }
 
     #[cfg(any(not(unix), not(target_pointer_width = "64")))]

--- a/src/udp_mux/udp_mux_test.rs
+++ b/src/udp_mux/udp_mux_test.rs
@@ -98,7 +98,7 @@ async fn test_udp_mux() -> Result<()> {
     });
 
     let (r1, r2, r3) = tokio::join!(h1, h2, h3);
-    let all_results = vec![r1, r2, r3];
+    let all_results = [r1, r2, r3];
 
     for timeout_result in &all_results {
         // Timeout error

--- a/src/udp_mux/udp_mux_test.rs
+++ b/src/udp_mux/udp_mux_test.rs
@@ -1,6 +1,5 @@
 use std::convert::TryInto;
 use std::io;
-use std::net::Ipv4Addr;
 use std::time::Duration;
 
 use super::*;
@@ -41,23 +40,28 @@ const TIMEOUT: Duration = Duration::from_secs(60);
 
 #[tokio::test]
 async fn test_udp_mux() -> Result<()> {
-    // use std::io::Write;
-    // env_logger::Builder::from_default_env()
-    //     .format(|buf, record| {
-    //         writeln!(
-    //             buf,
-    //             "{}:{} [{}] {} - {}",
-    //             record.file().unwrap_or("unknown"),
-    //             record.line().unwrap_or(0),
-    //             record.level(),
-    //             chrono::Local::now().format("%H:%M:%S.%6f"),
-    //             record.args()
-    //         )
-    //     })
-    //     .init();
+    use std::io::Write;
+    env_logger::Builder::from_default_env()
+        .format(|buf, record| {
+            writeln!(
+                buf,
+                "{}:{} [{}] {} - {}",
+                record.file().unwrap_or("unknown"),
+                record.line().unwrap_or(0),
+                record.level(),
+                chrono::Local::now().format("%H:%M:%S.%6f"),
+                record.args()
+            )
+        })
+        .init();
 
     // TODO: Support IPv6 dual stack. This works Linux and macOS, but not Windows.
-    let udp_socket = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0)).await?;
+    #[cfg(all(unix, target_pointer_width = "64"))]
+    let udp_socket = UdpSocket::bind((std::net::Ipv6Addr::UNSPECIFIED, 0)).await?;
+
+    #[cfg(any(not(unix), not(target_pointer_width = "64")))]
+    let udp_socket = UdpSocket::bind((std::net::Ipv4Addr::UNSPECIFIED, 0)).await?;
+
     let addr = udp_socket.local_addr()?;
     log::info!("Listening on {}", addr);
 
@@ -87,17 +91,17 @@ async fn test_udp_mux() -> Result<()> {
     #[cfg(all(unix, target_pointer_width = "64"))]
     {
         // TODO: Support IPv6 dual stack. This works Linux and macOS, but not Windows.
-        // let udp_mux_dyn_3 = Arc::clone(&udp_mux_dyn);
-        // let h3 = tokio::spawn(async move {
-        //     timeout(
-        //         TIMEOUT,
-        //         test_mux_connection(Arc::clone(&udp_mux_dyn_3), "ufrag3", addr, Network::Ipv6),
-        //     )
-        //     .await
-        // });
+        let udp_mux_dyn_3 = Arc::clone(&udp_mux_dyn);
+        let h3 = tokio::spawn(async move {
+            timeout(
+                TIMEOUT,
+                test_mux_connection(Arc::clone(&udp_mux_dyn_3), "ufrag3", addr, Network::Ipv6),
+            )
+            .await
+        });
 
-        let (r1, r2) = tokio::join!(h1, h2);
-        all_results = [r1, r2];
+        let (r1, r2, r3) = tokio::join!(h1, h2, h3);
+        all_results = [r1, r2, r3];
     }
 
     #[cfg(any(not(unix), not(target_pointer_width = "64")))]

--- a/src/udp_mux/udp_mux_test.rs
+++ b/src/udp_mux/udp_mux_test.rs
@@ -61,7 +61,7 @@ async fn test_udp_mux() -> Result<()> {
     let addr = udp_socket.local_addr()?;
     log::info!("Listening on {}", addr);
 
-    let udp_mux = UDPMuxDefault::new(UDPMuxParams { udp_socket });
+    let udp_mux = UDPMuxDefault::new(UDPMuxParams::new(udp_socket));
     let udp_mux_dyn = Arc::clone(&udp_mux) as Arc<dyn UDPMux + Send + Sync>;
 
     let udp_mux_dyn_1 = Arc::clone(&udp_mux_dyn);
@@ -134,7 +134,8 @@ async fn test_udp_mux() -> Result<()> {
         all_results
     );
 
-    udp_mux.close().await;
+    let res = udp_mux.close().await;
+    assert!(res.is_ok());
     let res = udp_mux.get_conn("failurefrag").await;
 
     assert!(

--- a/src/udp_mux/udp_mux_test.rs
+++ b/src/udp_mux/udp_mux_test.rs
@@ -56,6 +56,7 @@ async fn test_udp_mux() -> Result<()> {
     //     })
     //     .init();
 
+    // TODO: Support IPv6 dual stack. This works Linux and macOS, but not Windows.
     let udp_socket = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0)).await?;
     let addr = udp_socket.local_addr()?;
     log::info!("Listening on {}", addr);
@@ -85,6 +86,7 @@ async fn test_udp_mux() -> Result<()> {
 
     #[cfg(all(unix, target_pointer_width = "64"))]
     {
+        // TODO: Support IPv6 dual stack. This works Linux and macOS, but not Windows.
         // let udp_mux_dyn_3 = Arc::clone(&udp_mux_dyn);
         // let h3 = tokio::spawn(async move {
         //     timeout(

--- a/src/udp_mux/udp_mux_test.rs
+++ b/src/udp_mux/udp_mux_test.rs
@@ -1,0 +1,282 @@
+use std::convert::TryInto;
+use std::io;
+use std::time::Duration;
+
+use super::*;
+use crate::error::Result;
+use stun::message::*;
+
+use tokio::net::UdpSocket;
+use tokio::time::{sleep, timeout};
+
+use rand::{thread_rng, Rng};
+use sha1::{Digest, Sha1};
+
+#[derive(Debug, Copy, Clone)]
+enum Network {
+    Ipv4,
+    Ipv6,
+}
+
+impl Network {
+    /// Bind the UDP socket for the "remote".
+    async fn bind(&self) -> io::Result<UdpSocket> {
+        match self {
+            Network::Ipv4 => UdpSocket::bind("0.0.0.0:0").await,
+            Network::Ipv6 => UdpSocket::bind("[::]:0").await,
+        }
+    }
+
+    /// Connnect ip from the "remote".
+    fn connect_ip(&self, port: u16) -> String {
+        match self {
+            Network::Ipv4 => format!("127.0.0.1:{}", port),
+            Network::Ipv6 => format!("[::1]:{}", port),
+        }
+    }
+
+    /// The "remote" ip.  
+    fn remote_ip(&self, port: u16) -> String {
+        match self {
+            Network::Ipv4 => format!("[::ffff:127.0.0.1]:{}", port),
+            Network::Ipv6 => format!("[::1]:{}", port),
+        }
+    }
+}
+
+const TIMEOUT: Duration = Duration::from_secs(60);
+
+#[tokio::test]
+async fn test_udp_mux() -> Result<()> {
+    // use std::io::Write;
+    // env_logger::Builder::from_default_env()
+    //     .format(|buf, record| {
+    //         writeln!(
+    //             buf,
+    //             "{}:{} [{}] {} - {}",
+    //             record.file().unwrap_or("unknown"),
+    //             record.line().unwrap_or(0),
+    //             record.level(),
+    //             chrono::Local::now().format("%H:%M:%S.%6f"),
+    //             record.args()
+    //         )
+    //     })
+    //     .init();
+
+    let udp_socket = UdpSocket::bind("[::]:0").await?;
+    let addr = udp_socket.local_addr()?;
+    log::info!("Listening on {}", addr);
+
+    let udp_mux = UDPMuxDefault::new(UDPMuxParams { udp_socket });
+    let udp_mux_dyn = Arc::clone(&udp_mux) as Arc<dyn UDPMux + Send + Sync>;
+
+    let udp_mux_dyn_1 = Arc::clone(&udp_mux_dyn);
+    let h1 = tokio::spawn(async move {
+        timeout(
+            TIMEOUT,
+            test_mux_connection(Arc::clone(&udp_mux_dyn_1), "ufrag1", addr, Network::Ipv4),
+        )
+        .await
+    });
+
+    let udp_mux_dyn_2 = Arc::clone(&udp_mux_dyn);
+    let h2 = tokio::spawn(async move {
+        timeout(
+            TIMEOUT,
+            test_mux_connection(Arc::clone(&udp_mux_dyn_2), "ufrag2", addr, Network::Ipv4),
+        )
+        .await
+    });
+
+    let udp_mux_dyn_3 = Arc::clone(&udp_mux_dyn);
+    let h3 = tokio::spawn(async move {
+        timeout(
+            TIMEOUT,
+            test_mux_connection(Arc::clone(&udp_mux_dyn_3), "ufrag3", addr, Network::Ipv6),
+        )
+        .await
+    });
+
+    let (r1, r2, r3) = tokio::join!(h1, h2, h3);
+    let all_results = vec![r1, r2, r3];
+
+    for timeout_result in &all_results {
+        // Timeout error
+        match timeout_result {
+            Err(timeout_err) => {
+                assert!(false, "Mux test timedout: {:?}", timeout_err)
+            }
+
+            // Join error
+            Ok(join_result) => match join_result {
+                Err(err) => {
+                    assert!(false, "Mux test failed with join error: {:?}", err)
+                }
+                // Actual error
+                Ok(mux_result) => match mux_result {
+                    Err(err) => assert!(false, "Mux test failed with error: {:?}", err),
+                    _ => (),
+                },
+            },
+        }
+    }
+
+    let timeout = all_results.iter().find_map(|r| r.as_ref().err());
+    assert!(
+        timeout.is_none(),
+        "At least one of the muxed tasks timedout {:?}",
+        all_results
+    );
+
+    udp_mux.close().await;
+    let res = udp_mux.get_conn("failurefrag").await;
+
+    assert!(
+        res.is_err(),
+        "Getting connections after UDPMuxDefault is closed should fail"
+    );
+
+    Ok(())
+}
+
+async fn test_mux_connection(
+    mux: Arc<dyn UDPMux + Send + Sync>,
+    ufrag: &str,
+    listener_addr: SocketAddr,
+    network: Network,
+) -> Result<()> {
+    let conn = mux.get_conn(ufrag).await?;
+    // FIXME: Cleanup
+
+    let connect_addr = network
+        .connect_ip(listener_addr.port())
+        .parse::<SocketAddr>()
+        .unwrap();
+
+    let remote_connection = Arc::new(network.bind().await?);
+    log::info!("Bound for ufrag: {}", ufrag);
+    remote_connection.connect(connect_addr).await?;
+    log::info!("Connected to {} for ufrag: {}", connect_addr, ufrag);
+    log::info!(
+        "Testing muxing from {} over {}",
+        remote_connection.local_addr().unwrap(),
+        listener_addr
+    );
+
+    // These bytes should be dropped
+    remote_connection.send("Droppped bytes".as_bytes()).await?;
+
+    sleep(Duration::from_millis(1)).await;
+
+    let stun_msg = {
+        let mut m = Message::default();
+        m.typ = BINDING_REQUEST;
+        m.add(ATTR_USERNAME, format!("{}:otherufrag", ufrag).as_bytes());
+
+        m.marshal_binary().unwrap()
+    };
+
+    let remote_connection_addr = network
+        .remote_ip(remote_connection.local_addr()?.port())
+        .parse::<SocketAddr>()
+        .unwrap();
+
+    conn.send_to(&stun_msg, remote_connection_addr).await?;
+
+    let mut buffer = vec![0u8; RECEIVE_MTU];
+    let len = remote_connection.recv(&mut buffer).await?;
+    assert_eq!(buffer[..len], stun_msg);
+
+    const TARGET_SIZE: usize = 1 * 1024 * 1024;
+
+    // Read on the muxed side
+    let conn_2 = Arc::clone(&conn);
+    let mux_handle = tokio::spawn(async move {
+        let conn = conn_2;
+
+        let mut buffer = vec![0u8; RECEIVE_MTU];
+        let mut next_sequence = 0;
+        let mut read = 0;
+
+        while read < TARGET_SIZE {
+            let (n, _) = conn
+                .recv_from(&mut buffer)
+                .await
+                .expect("recv_from should not error");
+            assert_eq!(n, RECEIVE_MTU);
+
+            verify_packet(&buffer[..n], next_sequence);
+
+            conn.send_to(&buffer[..n], remote_connection_addr)
+                .await
+                .expect("Failed to write to muxxed connection");
+
+            read += n;
+            log::debug!("Muxxed read {}, sequence: {}", read, next_sequence);
+            next_sequence += 1;
+        }
+    });
+
+    let remote_connection_2 = Arc::clone(&remote_connection);
+    let remote_handle = tokio::spawn(async move {
+        let remote_connection = remote_connection_2;
+        let mut buffer = vec![0u8; RECEIVE_MTU];
+        let mut next_sequence = 0;
+        let mut read = 0;
+
+        while read < TARGET_SIZE {
+            let n = remote_connection
+                .recv(&mut buffer)
+                .await
+                .expect("recv_from should not error");
+            assert_eq!(n, RECEIVE_MTU);
+
+            verify_packet(&buffer[..n], next_sequence);
+            read += n;
+            log::debug!("Remote read {}, sequence: {}", read, next_sequence);
+            next_sequence += 1;
+        }
+    });
+
+    let mut sequence: u32 = 0;
+    let mut written = 0;
+    let mut buffer = vec![0u8; RECEIVE_MTU];
+    while written < TARGET_SIZE {
+        thread_rng().fill(&mut buffer[24..]);
+
+        let hash = sha1_hash(&buffer[24..]);
+        buffer[4..24].copy_from_slice(&hash);
+        buffer[0..4].copy_from_slice(&sequence.to_le_bytes());
+
+        let len = remote_connection.send(&buffer).await?;
+
+        written += len;
+        log::debug!("Data written {}, sequence: {}", written, sequence);
+        sequence += 1;
+
+        sleep(Duration::from_millis(1)).await;
+    }
+
+    let (r1, r2) = tokio::join!(mux_handle, remote_handle);
+    assert!(r1.is_ok() && r2.is_ok());
+
+    let res = conn.close().await;
+    assert!(res.is_ok(), "Failed to close Conn: {:?}", res);
+
+    Ok(())
+}
+
+fn verify_packet(buffer: &[u8], next_sequence: u32) {
+    let read_sequence = u32::from_le_bytes(buffer[0..4].try_into().unwrap());
+    assert_eq!(read_sequence, next_sequence);
+
+    let hash = sha1_hash(&buffer[24..]);
+    assert_eq!(hash, buffer[4..24]);
+}
+
+fn sha1_hash(buffer: &[u8]) -> Vec<u8> {
+    let mut hasher = Sha1::new();
+    hasher.update(&buffer[24..]);
+
+    hasher.finalize().to_vec()
+}


### PR DESCRIPTION
Implement UDP muxing for ICE for https://github.com/webrtc-rs/webrtc/issues/102.

Tasks:

+ [x] Port [UDPMux](https://github.com/pion/ice/blob/master/udp_mux.go).
+ [x] Port tests for `UDPMux`
+ [x] Hook up UDPMux in ICE gathering/agent
+ [x] Tests for ICE gathering/agent with UDP mux
+ [x] Support UDPMux in `SettingsEngine`
+ [x] Port UDPMux example
+ [x] Do a self review of all this 
+ [x] Adopt `parking_lot`'s sync primitives via `webrtc-util`

~~I've used `std::sync::Mutex` rather than `tokio::sync::Mutex` in a few places. This is based on Tokio's [recommendations](https://tokio.rs/tokio/tutorial/shared-state#on-using-stdsyncmutex) to prefer `std::sync::Mutex`, however in their own codebase Tokio does away with the erroring by removing the poision mechanics. Happy to convert these to `tokio::sync::Mutex` too.~~