### PR TITLE
Add validation for Ephemeral UDP port range

### DIFF
--- a/examples/ping_pong.rs
+++ b/examples/ping_pong.rs
@@ -6,7 +6,7 @@ use ice::agent::Agent;
 use ice::candidate::{candidate_base::*, *};
 use ice::state::*;
 use ice::Error;
-use ice::{network_type::*, UDPNetwork};
+use ice::{network_type::*, udp_network::UDPNetwork};
 
 use clap::{App, AppSettings, Arg};
 use hyper::service::{make_service_fn, service_fn};

--- a/src/agent/agent_config.rs
+++ b/src/agent/agent_config.rs
@@ -2,8 +2,8 @@ use super::*;
 use crate::error::*;
 use crate::mdns::*;
 use crate::network_type::*;
+use crate::udp_network::UDPNetwork;
 use crate::url::*;
-use crate::UDPNetwork;
 
 use util::vnet::net::*;
 

--- a/src/agent/agent_gather.rs
+++ b/src/agent/agent_gather.rs
@@ -1,9 +1,9 @@
 use super::*;
 use crate::error::*;
 use crate::network_type::*;
+use crate::udp_network::UDPNetwork;
 use crate::url::{ProtoType, SchemeType, Url};
 use crate::util::*;
-use crate::UDPNetwork;
 
 use util::{vnet::net::*, Conn};
 
@@ -114,8 +114,8 @@ impl Agent {
                     let srflx_params = GatherCandidatesSrflxParams {
                         urls: params.urls.clone(),
                         network_types: params.network_types.clone(),
-                        port_max: ephemeral_config.port_max,
-                        port_min: ephemeral_config.port_min,
+                        port_max: ephemeral_config.port_max(),
+                        port_min: ephemeral_config.port_min(),
                         net: Arc::clone(&params.net),
                         agent_internal: Arc::clone(&params.agent_internal),
                     };
@@ -129,8 +129,8 @@ impl Agent {
                         if ext_ip_mapper.candidate_type == CandidateType::ServerReflexive {
                             let srflx_mapped_params = GatherCandidatesSrflxMappedParasm {
                                 network_types: params.network_types.clone(),
-                                port_max: ephemeral_config.port_max,
-                                port_min: ephemeral_config.port_min,
+                                port_max: ephemeral_config.port_max(),
+                                port_min: ephemeral_config.port_min(),
                                 ext_ip_mapper: Arc::clone(&params.ext_ip_mapper),
                                 net: Arc::clone(&params.net),
                                 agent_internal: Arc::clone(&params.agent_internal),
@@ -277,8 +277,8 @@ impl Agent {
 
                 let conn: Arc<dyn Conn + Send + Sync> = match listen_udp_in_port_range(
                     &net,
-                    ephemeral_config.port_max,
-                    ephemeral_config.port_min,
+                    ephemeral_config.port_max(),
+                    ephemeral_config.port_min(),
                     SocketAddr::new(ip, 0),
                 )
                 .await

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -21,8 +21,8 @@ use crate::mdns::*;
 use crate::network_type::*;
 use crate::state::*;
 use crate::udp_mux::UDPMux;
+use crate::udp_network::UDPNetwork;
 use crate::url::*;
-use crate::UDPNetwork;
 use agent_config::*;
 use agent_internal::*;
 use agent_stats::*;
@@ -115,15 +115,6 @@ pub struct Agent {
 impl Agent {
     /// Creates a new Agent.
     pub async fn new(config: AgentConfig) -> Result<Self> {
-        match &config.udp_network {
-            crate::UDPNetwork::Ephemeral(ephemeral) => {
-                if ephemeral.port_max < ephemeral.port_min {
-                    return Err(Error::ErrPort);
-                }
-            }
-            crate::UDPNetwork::Muxed(_) => {}
-        }
-
         let mut mdns_name = config.multicast_dns_host_name.clone();
         if mdns_name.is_empty() {
             mdns_name = generate_multicast_dns_name();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,6 @@
 #![warn(rust_2018_idioms)]
 #![allow(dead_code)]
 
-use std::sync::Arc;
-
 pub mod agent;
 pub mod candidate;
 pub mod control;
@@ -16,49 +14,9 @@ pub mod state;
 pub mod stats;
 pub mod tcp_type;
 pub mod udp_mux;
+pub mod udp_network;
 pub mod url;
 pub mod use_candidate;
 mod util;
-
-#[derive(Default, Clone)]
-pub struct EphemeralUDP {
-    pub port_min: u16,
-    pub port_max: u16,
-}
-
-/// Configuration for the underlying UDP network stack.
-/// There are two ways to configure this Ephemeral and Muxed.
-///
-/// **Ephemeral mode**
-///
-/// In Ephemeral mode sockets are created and bound to random ports during ICE
-/// gathering. The ports to use can be restricted by setting [`EphemeralUDP::port_min`] and
-/// [`EphemeralEphemeralUDP::port_max`] in which case only ports in this range will be used.
-///
-/// **Muxed**
-///
-/// In muxed mode a single UDP socket is used and all connections are muxed over this single socket.
-///
-#[derive(Clone)]
-pub enum UDPNetwork {
-    Ephemeral(EphemeralUDP),
-    Muxed(Arc<dyn udp_mux::UDPMux + Send + Sync>),
-}
-
-impl Default for UDPNetwork {
-    fn default() -> Self {
-        Self::Ephemeral(Default::default())
-    }
-}
-
-impl UDPNetwork {
-    fn is_ephemeral(&self) -> bool {
-        matches!(self, Self::Ephemeral(_))
-    }
-
-    fn is_muxed(&self) -> bool {
-        matches!(self, Self::Muxed(_))
-    }
-}
 
 pub use error::Error;

--- a/src/udp_network.rs
+++ b/src/udp_network.rs
@@ -1,0 +1,116 @@
+use std::sync::Arc;
+
+use super::udp_mux::UDPMux;
+use super::Error;
+
+#[derive(Default, Clone)]
+pub struct EphemeralUDP {
+    port_min: u16,
+    port_max: u16,
+}
+
+impl EphemeralUDP {
+    pub fn new(port_min: u16, port_max: u16) -> Result<Self, Error> {
+        let mut s = Self::default();
+        s.set_ports(port_min, port_max)?;
+
+        Ok(s)
+    }
+
+    pub fn port_min(&self) -> u16 {
+        self.port_min
+    }
+
+    pub fn port_max(&self) -> u16 {
+        self.port_max
+    }
+
+    pub fn set_ports(&mut self, port_min: u16, port_max: u16) -> Result<(), Error> {
+        if port_max < port_min {
+            return Err(Error::ErrPort);
+        }
+
+        self.port_min = port_min;
+        self.port_max = port_max;
+
+        Ok(())
+    }
+}
+
+/// Configuration for the underlying UDP network stack.
+/// There are two ways to configure this Ephemeral and Muxed.
+///
+/// **Ephemeral mode**
+///
+/// In Ephemeral mode sockets are created and bound to random ports during ICE
+/// gathering. The ports to use can be restricted by setting [`EphemeralUDP::port_min`] and
+/// [`EphemeralEphemeralUDP::port_max`] in which case only ports in this range will be used.
+///
+/// **Muxed**
+///
+/// In muxed mode a single UDP socket is used and all connections are muxed over this single socket.
+///
+#[derive(Clone)]
+pub enum UDPNetwork {
+    Ephemeral(EphemeralUDP),
+    Muxed(Arc<dyn UDPMux + Send + Sync>),
+}
+
+impl Default for UDPNetwork {
+    fn default() -> Self {
+        Self::Ephemeral(Default::default())
+    }
+}
+
+impl UDPNetwork {
+    fn is_ephemeral(&self) -> bool {
+        matches!(self, Self::Ephemeral(_))
+    }
+
+    fn is_muxed(&self) -> bool {
+        matches!(self, Self::Muxed(_))
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{EphemeralUDP, UDPNetwork};
+
+    #[test]
+    fn test_ephemeral_udp_constructor() {
+        assert!(
+            EphemeralUDP::new(3000, 2999).is_err(),
+            "EphemeralUDP should not allow invalid port range"
+        );
+
+        let e = EphemeralUDP::default();
+        assert_eq!(e.port_min(), 0, "EphemeralUDP should default port_min to 0");
+        assert_eq!(e.port_max(), 0, "EphemeralUDP should default port_max to 0");
+    }
+
+    #[test]
+    fn test_ephemeral_udp_set_ports() {
+        let mut e = EphemeralUDP::default();
+
+        assert!(
+            e.set_ports(3000, 2999).is_err(),
+            "EphemeralUDP should not allow invalid port range"
+        );
+
+        assert!(
+            e.set_ports(6000, 6001).is_ok(),
+            "EphemeralUDP::set_ports should allow valid port range"
+        );
+
+        assert_eq!(
+            e.port_min(),
+            6000,
+            "Ports set with `EphemeralUDP::set_ports` should be reflected"
+        );
+        assert_eq!(
+            e.port_max(),
+            6001,
+            "Ports set with `EphemeralUDP::set_ports` should be reflected"
+        );
+    }
+}


### PR DESCRIPTION
This validation will no longer be in `SettingsEngine` in `webrtc`. To maintain it I've moved it to `EphemeralUDP`.
