### PR TITLE
Fix closing connection for UDP mux

### DIFF
--- a/src/udp_mux/udp_mux_conn.rs
+++ b/src/udp_mux/udp_mux_conn.rs
@@ -261,9 +261,6 @@ impl Conn for UDPMuxConn {
     }
 
     async fn send_to(&self, buf: &[u8], target: SocketAddr) -> ConnResult<usize> {
-        if self.is_closed() {
-            return Err(Error::ErrUseClosedNetworkConn);
-        }
         let normalized_target = normalize_socket_addr(&target, &self.inner.params.local_addr);
 
         if !self.contains_address(&normalized_target) {


### PR DESCRIPTION
When a connection has been closed it seems like upstream code relies on
an IoError being returned to stop sending. By returning
`Error::ErrUseClosedNetworkConn` this wasn't being triggered.
