### PR TITLE
Prevent UDP mux from removing connections

### DIFF
--- a/src/udp_mux/mod.rs
+++ b/src/udp_mux/mod.rs
@@ -136,8 +136,10 @@ impl UDPMuxDefault {
             addresses
                 .entry(addr)
                 .and_modify(|e| {
-                    e.remove_address(&addr);
-                    *e = conn.clone()
+                    if e.key() != key {
+                        e.remove_address(&addr);
+                        *e = conn.clone()
+                    }
                 })
                 .or_insert_with(|| conn.clone());
         }


### PR DESCRIPTION
UDP mux can get into a loop where it repeatedly removes and adds the
address because:

1. We add the address in `UDPMuxConn::send_to` via
   `UDPMuxConn::add_address` .
2. `UDPMuxConn::add_address` calls `UDPMux::register_conn_for_address`
3. `UDPMux::register_conn_for_address` removes the address we just added and closes
   the conn if it existed. Then, the next time we send this starts again
   from 1.
