### PR TITLE
Serializers for CandidateType, CandidatePairState, NetworkType

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,19 +12,21 @@ repository = "https://github.com/webrtc-rs/ice"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-util = { package = "webrtc-util", version = "0.5.3", default-features = false, features = ["conn", "vnet", "sync"] }
-mdns = { package = "webrtc-mdns", version = "0.4.2" }
-stun = "0.4.2"
-turn = "0.5.4"
-tokio = { version = "1.15.0", features = ["full"] }
-url = "2.2.2"
-crc = "2.1.0"
-uuid = { version = "0.8.2", features = ["v4"] }
-rand = "0.8.4"
-log = "0.4.14"
 async-trait = "0.1.52"
-waitgroup = "0.1.2"
+crc = "2.1.0"
+log = "0.4.14"
+mdns = { package = "webrtc-mdns", version = "0.4.2" }
+rand = "0.8.4"
+serde = { version = "1.0.132", features = ["derive"] }
+serde_json = "1.0.73"
+stun = "0.4.2"
 thiserror = "1.0.30"
+tokio = { version = "1.15.0", features = ["full"] }
+turn = "0.5.4"
+url = "2.2.2"
+util = { package = "webrtc-util", version = "0.5.3", default-features = false, features = ["conn", "vnet", "sync"] }
+uuid = { version = "0.8.2", features = ["v4"] }
+waitgroup = "0.1.2"
 
 [dev-dependencies]
 tokio-test = "0.4.2"

--- a/src/candidate/candidate_test.rs
+++ b/src/candidate/candidate_test.rs
@@ -234,6 +234,73 @@ fn test_candidate_foundation() -> Result<()> {
     Ok(())
 }
 
+#[test]
+fn test_candidate_pair_state_serialization() {
+    let tests = vec![
+        (CandidatePairState::Unspecified, "\"unspecified\""),
+        (CandidatePairState::Waiting, "\"waiting\""),
+        (CandidatePairState::InProgress, "\"in-progress\""),
+        (CandidatePairState::Failed, "\"failed\""),
+        (CandidatePairState::Succeeded, "\"succeeded\""),
+    ];
+
+    for (candidate_pair_state, expected_string) in tests {
+        assert_eq!(
+            expected_string.to_string(),
+            serde_json::to_string(&candidate_pair_state).unwrap()
+        );
+    }
+}
+
+#[test]
+fn test_candidate_pair_state_to_string() {
+    let tests = vec![
+        (CandidatePairState::Unspecified, "unspecified"),
+        (CandidatePairState::Waiting, "waiting"),
+        (CandidatePairState::InProgress, "in-progress"),
+        (CandidatePairState::Failed, "failed"),
+        (CandidatePairState::Succeeded, "succeeded"),
+    ];
+
+    for (candidate_pair_state, expected_string) in tests {
+        assert_eq!(expected_string, candidate_pair_state.to_string());
+    }
+}
+
+
+#[test]
+fn test_candidate_type_serialization() {
+    let tests = vec![
+        (CandidateType::Unspecified, "\"unspecified\""),
+        (CandidateType::Host, "\"host\""),
+        (CandidateType::ServerReflexive, "\"srflx\""),
+        (CandidateType::PeerReflexive, "\"prflx\""),
+        (CandidateType::Relay, "\"relay\""),
+    ];
+
+    for (candidate_type, expected_string) in tests {
+        assert_eq!(
+            expected_string.to_string(),
+            serde_json::to_string(&candidate_type).unwrap()
+        );
+    }
+}
+
+#[test]
+fn test_candidate_type_to_string() {
+    let tests = vec![
+        (CandidateType::Unspecified, "Unknown candidate type"),
+        (CandidateType::Host, "host"),
+        (CandidateType::ServerReflexive, "srflx"),
+        (CandidateType::PeerReflexive, "prflx"),
+        (CandidateType::Relay, "relay"),
+    ];
+
+    for (candidate_type, expected_string) in tests {
+        assert_eq!(expected_string, candidate_type.to_string());
+    }
+}
+
 #[tokio::test]
 async fn test_candidate_marshal() -> Result<()> {
     let tests = vec![

--- a/src/candidate/mod.rs
+++ b/src/candidate/mod.rs
@@ -19,6 +19,7 @@ use crate::tcp_type::*;
 use candidate_base::*;
 
 use async_trait::async_trait;
+use serde::Serialize;
 use std::fmt;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::atomic::{AtomicBool, AtomicU16, AtomicU8, Ordering};
@@ -86,12 +87,17 @@ pub trait Candidate: fmt::Display {
 }
 
 /// Represents the type of candidate `CandidateType` enum.
-#[derive(PartialEq, Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
 pub enum CandidateType {
+    #[serde(rename = "unspecified")]
     Unspecified,
+    #[serde(rename = "host")]
     Host,
+    #[serde(rename = "srflx")]
     ServerReflexive,
+    #[serde(rename = "prflx")]
     PeerReflexive,
+    #[serde(rename = "relay")]
     Relay,
 }
 
@@ -163,21 +169,26 @@ impl fmt::Display for CandidateRelatedAddress {
 }
 
 /// Represent the ICE candidate pair state.
-#[derive(PartialEq, Debug, Copy, Clone)]
+#[derive(Clone, Copy, Debug, PartialEq, Serialize)]
 pub enum CandidatePairState {
+    #[serde(rename = "unspecified")]
     Unspecified = 0,
 
     /// Means a check has not been performed for this pair.
+    #[serde(rename = "waiting")]
     Waiting = 1,
 
     /// Means a check has been sent for this pair, but the transaction is in progress.
+    #[serde(rename = "in-progress")]
     InProgress = 2,
 
     /// Means a check for this pair was already done and failed, either never producing any response
     /// or producing an unrecoverable failure response.
+    #[serde(rename = "failed")]
     Failed = 3,
 
     /// Means a check for this pair was already done and produced a successful result.
+    #[serde(rename = "succeeded")]
     Succeeded = 4,
 }
 

--- a/src/network_type/mod.rs
+++ b/src/network_type/mod.rs
@@ -3,6 +3,7 @@ mod network_type_test;
 
 use crate::error::*;
 
+use serde::{Deserialize, Serialize};
 use std::fmt;
 use std::net::IpAddr;
 
@@ -20,20 +21,25 @@ pub fn supported_network_types() -> Vec<NetworkType> {
 }
 
 /// Represents the type of network.
-#[derive(PartialEq, Debug, Copy, Clone, Eq, Hash)]
+#[derive(PartialEq, Debug, Copy, Clone, Eq, Hash, Serialize, Deserialize)]
 pub enum NetworkType {
+    #[serde(rename = "unspecified")]
     Unspecified,
 
     /// Indicates UDP over IPv4.
+    #[serde(rename = "udp4")]
     Udp4,
 
     /// Indicates UDP over IPv6.
+    #[serde(rename = "udp6")]
     Udp6,
 
     /// Indicates TCP over IPv4.
+    #[serde(rename = "tcp4")]
     Tcp4,
 
     /// Indicates TCP over IPv6.
+    #[serde(rename = "tcp6")]
     Tcp6,
 }
 

--- a/src/network_type/network_type_test.rs
+++ b/src/network_type/network_type_test.rs
@@ -63,3 +63,36 @@ fn test_network_type_is_tcp() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_network_type_serialization() {
+    let tests = vec![
+        (NetworkType::Tcp4, "\"tcp4\""),
+        (NetworkType::Tcp6, "\"tcp6\""),
+        (NetworkType::Udp4, "\"udp4\""),
+        (NetworkType::Udp6, "\"udp6\""),
+        (NetworkType::Unspecified, "\"unspecified\""),
+    ];
+
+    for (network_type, expected_string) in tests {
+        assert_eq!(
+            expected_string.to_string(),
+            serde_json::to_string(&network_type).unwrap()
+        );
+    }
+}
+
+#[test]
+fn test_network_type_to_string() {
+    let tests = vec![
+        (NetworkType::Tcp4, "tcp4"),
+        (NetworkType::Tcp6, "tcp6"),
+        (NetworkType::Udp4, "udp4"),
+        (NetworkType::Udp6, "udp6"),
+        (NetworkType::Unspecified, "unspecified"),
+    ];
+
+    for (network_type, expected_string) in tests {
+        assert_eq!(expected_string, network_type.to_string());
+    }
+}


### PR DESCRIPTION
I'm working on adding the ability to serialize webrtc stats to JSON, and these enums will need serializers in order for that to work across crates.