### PR TITLE
Agent can get_bytes_received and get_bytes_sent

### DIFF
--- a/src/agent/agent_test.rs
+++ b/src/agent/agent_test.rs
@@ -166,6 +166,27 @@ async fn test_pair_priority() -> Result<()> {
 }
 
 #[tokio::test]
+async fn test_agent_get_stats() -> Result<()> {
+    let (conn_a, conn_b, agent_a, agent_b) = pipe(None, None).await?;
+    assert_eq!(agent_a.get_bytes_received().await, 0);
+    assert_eq!(agent_a.get_bytes_sent().await, 0);
+    assert_eq!(agent_b.get_bytes_received().await, 0);
+    assert_eq!(agent_b.get_bytes_sent().await, 0);
+
+    let _na = conn_a.send(&[0u8; 10]).await?;
+    let mut buf = vec![0u8; 10];
+    let _nb = conn_b.recv(&mut buf).await?;
+
+    assert_eq!(agent_a.get_bytes_received().await, 0);
+    assert_eq!(agent_a.get_bytes_sent().await, 10);
+
+    assert_eq!(agent_b.get_bytes_received().await, 10);
+    assert_eq!(agent_b.get_bytes_sent().await, 0);
+
+    Ok(())
+}
+
+#[tokio::test]
 async fn test_on_selected_candidate_pair_change() -> Result<()> {
     let a = Agent::new(AgentConfig::default()).await?;
     let (callback_called_tx, mut callback_called_rx) = mpsc::channel::<()>(1);

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -227,6 +227,14 @@ impl Agent {
         Ok(agent)
     }
 
+    pub async fn get_bytes_received(&self) -> usize {
+        self.internal.agent_conn.bytes_received()
+    }
+
+    pub async fn get_bytes_sent(&self) -> usize {
+        self.internal.agent_conn.bytes_sent()
+    }
+
     /// Sets a handler that is fired when the connection state changes.
     pub async fn on_connection_state_change(&self, f: OnConnectionStateChangeHdlrFn) {
         let mut on_connection_state_change_hdlr =


### PR DESCRIPTION
I don't see a good way to connect two agents together in the tests, but it would be nice to see values greater than 0.