### PR TITLE
Expose UDPMuxConn and UDPMuxConnParams 

### DIFF
--- a/src/udp_mux/mod.rs
+++ b/src/udp_mux/mod.rs
@@ -7,7 +7,7 @@ use async_trait::async_trait;
 use tokio::sync::{watch, Mutex};
 
 mod udp_mux_conn;
-pub use udp_mux_conn::{UDPMuxConn, UDPMuxCyclic, UDPMuxConnParams};
+pub use udp_mux_conn::{UDPMuxConn, UDPMuxConnParams, WeakUDPMux};
 
 #[cfg(test)]
 mod udp_mux_test;
@@ -332,51 +332,26 @@ impl UDPMux for UDPMuxDefault {
             }
         }
     }
-
 }
 
 #[async_trait]
-impl UDPMuxCyclic for Weak<UDPMuxDefault> {
+impl WeakUDPMux for Weak<UDPMuxDefault> {
     async fn register_conn_for_address(&self, conn: &UDPMuxConn, addr: SocketAddr) {
-        let me = self.upgrade();
-        if me.is_none() {
-            return;
+        if let Some(mux) = self.upgrade() {
+            mux.register_conn_for_address(conn, addr).await;
         }
-        let me = me.unwrap();
-
-        if me.is_closed().await {
-            return;
-        }
-
-        let key = conn.key();
-        {
-            let mut addresses = me.address_map.write();
-
-            addresses
-                .entry(addr)
-                .and_modify(|e| {
-                    if e.key() != key {
-                        e.remove_address(&addr);
-                        *e = conn.clone()
-                    }
-                })
-                .or_insert_with(|| conn.clone());
-        }
-
-        log::debug!("Registered {} for {}", addr, key);
     }
 
     async fn send_to(&self, buf: &[u8], target: &SocketAddr) -> Result<usize, Error> {
-        let me = self.upgrade();
-        if me.is_none() {
-            return Err(Error::Other("send_to called, but UDPMuxDefault is gone".to_string()));
+        match self.upgrade() {
+            Some(mux) => mux.send_to(buf, target).await,
+            None => {
+                return Err(Error::Other(format!(
+                    "wanted to send {} bytes to {}, but UDP muxer is gone",
+                    buf.len(),
+                    target
+                )))
+            }
         }
-
-        let me = me.unwrap();
-        me.params
-            .conn
-            .send_to(buf, *target)
-            .await
-            .map_err(Into::into)
     }
 }

--- a/src/udp_mux/mod.rs
+++ b/src/udp_mux/mod.rs
@@ -328,7 +328,6 @@ impl UDPMuxWriter for UDPMuxDefault {
         log::debug!("Registered {} for {}", addr, key);
     }
 
-
     async fn send_to(&self, buf: &[u8], target: &SocketAddr) -> Result<usize, Error> {
         self.params
             .conn

--- a/src/udp_mux/udp_mux_conn.rs
+++ b/src/udp_mux/udp_mux_conn.rs
@@ -29,13 +29,6 @@ pub struct UDPMuxConnParams {
     /// A `std::sync::Weak` reference to the UDP mux.
     ///
     /// NOTE: a non-owning reference should be used to prevent possible cycles.
-    ///
-    /// ```no_run
-    /// let params = UDPMuxConnParams {
-    ///     udp_mux: Arc::downgrade(udp_mux_arc) as Weak<dyn UDPMuxWriter + Send + Sync>,
-    ///     ...
-    /// };
-    /// ```
     pub udp_mux: Weak<dyn UDPMuxWriter + Send + Sync>,
 }
 

--- a/src/udp_mux/udp_mux_conn.rs
+++ b/src/udp_mux/udp_mux_conn.rs
@@ -9,28 +9,141 @@ use util::{sync::Mutex, Buffer, Conn, Error};
 use super::socket_addr_ext::{SocketAddrExt, MAX_ADDR_SIZE};
 use super::{normalize_socket_addr, RECEIVE_MTU};
 
-#[inline(always)]
-/// Create a buffer of appropriate size to fit both a packet with max RECEIVE_MTU and the
-/// additional metadata used for muxing.
-fn make_buffer() -> Vec<u8> {
-    // The 4 extra bytes are used to encode the length of the data and address respectively.
-    // See [`write_packet`] for details.
-    vec![0u8; RECEIVE_MTU + MAX_ADDR_SIZE + 2 + 2]
-}
-
+/// A trait for a [`UDPMuxConn`] to communicate with an UDP mux.
 #[async_trait]
-pub trait UDPMuxCyclic {
+pub trait WeakUDPMux {
+    /// Registers an address for the given connection.
     async fn register_conn_for_address(&self, conn: &UDPMuxConn, addr: SocketAddr);
+    /// Sends the content of the buffer to the given target.
+    ///
+    /// Returns the number of bytes sent or an error, if any.
     async fn send_to(&self, buf: &[u8], target: &SocketAddr) -> Result<usize, Error>;
 }
 
+/// Parameters for a [`UDPMuxConn`].
 pub struct UDPMuxConnParams {
+    /// Local socket address.
     pub local_addr: SocketAddr,
+    /// Static key identifying the connection.
     pub key: String,
-    // NOTE: This Arc exists in both directions which is liable to cause a retain cycle. This is
-    // accounted for in [`UDPMuxDefault::close`], which makes sure to drop all Arcs referencing any
-    // `UDPMuxConn`.
-    pub udp_mux: Box<dyn UDPMuxCyclic + Send + Sync>,
+    /// A `std::sync::Weak` reference to the UDP mux.
+    ///
+    /// NOTE: a non-owning reference should be used to prevent possible cycles.
+    ///
+    /// ```no_run
+    /// let params = UDPMuxConnParams {
+    ///     udp_mux: Box::new(Arc::downgrade(udp_mux_arc)),
+    ///     ...
+    /// };
+    /// ```
+    ///
+    /// See [`WeakUDPMux`].
+    pub udp_mux: Box<dyn WeakUDPMux + Send + Sync>,
+}
+
+type ConnResult<T> = Result<T, util::Error>;
+
+/// A UDP mux connection.
+#[derive(Clone)]
+pub struct UDPMuxConn {
+    /// Close Receiver. A copy of this can be obtained via [`close_tx`].
+    closed_watch_rx: watch::Receiver<bool>,
+
+    inner: Arc<UDPMuxConnInner>,
+}
+
+impl UDPMuxConn {
+    /// Creates a new [`UDPMuxConn`].
+    pub fn new(params: UDPMuxConnParams) -> Self {
+        let (closed_watch_tx, closed_watch_rx) = watch::channel(false);
+
+        Self {
+            closed_watch_rx,
+            inner: Arc::new(UDPMuxConnInner {
+                params,
+                closed_watch_tx: Mutex::new(Some(closed_watch_tx)),
+                addresses: Default::default(),
+                buffer: Buffer::new(0, 0),
+            }),
+        }
+    }
+
+    /// Returns a key identifying this connection.
+    pub fn key(&self) -> &str {
+        &self.inner.params.key
+    }
+
+    /// Writes data to the given address. Returns an error if the buffer is too short or there's an
+    /// encoding error.
+    pub async fn write_packet(&self, data: &[u8], addr: SocketAddr) -> ConnResult<()> {
+        // NOTE: Pion/ice uses Sync.Pool to optimise this.
+        let mut buffer = make_buffer();
+        let mut offset = 0;
+
+        if (data.len() + MAX_ADDR_SIZE) > (RECEIVE_MTU + MAX_ADDR_SIZE) {
+            return Err(Error::ErrBufferShort);
+        }
+
+        // Format of buffer: | data len(2) | data bytes(dn) | addr len(2) | addr bytes(an) |
+        // Where the number in parenthesis indicate the number of bytes used
+        // `dn` and `an` are the length in bytes of data and addr respectively.
+
+        // SAFETY: `data.len()` is at most RECEIVE_MTU(8192) - MAX_ADDR_SIZE(27)
+        buffer[0..2].copy_from_slice(&(data.len() as u16).to_le_bytes()[..]);
+        offset += 2;
+
+        buffer[offset..offset + data.len()].copy_from_slice(data);
+        offset += data.len();
+
+        let len = addr.encode(&mut buffer[offset + 2..])?;
+        buffer[offset..offset + 2].copy_from_slice(&(len as u16).to_le_bytes()[..]);
+        offset += 2 + len;
+
+        self.inner.buffer.write(&buffer[..offset]).await?;
+
+        Ok(())
+    }
+
+    /// Returns true if this connection is closed.
+    pub fn is_closed(&self) -> bool {
+        self.inner.is_closed()
+    }
+
+    /// Gets a copy of the close [`tokio::sync::watch::Receiver`] that fires when this
+    /// connection is closed.
+    pub fn close_rx(&self) -> watch::Receiver<bool> {
+        self.closed_watch_rx.clone()
+    }
+
+    /// Closes this connection.
+    pub fn close(&self) {
+        self.inner.close();
+    }
+
+    /// Gets the list of the addresses associated with this connection.
+    pub fn get_addresses(&self) -> Vec<SocketAddr> {
+        self.inner.get_addresses()
+    }
+
+    /// Registers a new address for this connection.
+    pub async fn add_address(&self, addr: SocketAddr) {
+        self.inner.add_address(addr);
+        self.inner
+            .params
+            .udp_mux
+            .register_conn_for_address(self, addr)
+            .await;
+    }
+
+    /// Deregisters an address.
+    pub fn remove_address(&self, addr: &SocketAddr) {
+        self.inner.remove_address(addr)
+    }
+
+    /// Returns true if the given address is associated with this connection.
+    pub fn contains_address(&self, addr: &SocketAddr) -> bool {
+        self.inner.contains_address(addr)
+    }
 }
 
 struct UDPMuxConnInner {
@@ -151,101 +264,6 @@ impl UDPMuxConnInner {
     }
 }
 
-#[derive(Clone)]
-pub struct UDPMuxConn {
-    /// Close Receiver. A copy of this can be obtained via [`close_tx`].
-    closed_watch_rx: watch::Receiver<bool>,
-
-    inner: Arc<UDPMuxConnInner>,
-}
-
-impl UDPMuxConn {
-    pub fn new(params: UDPMuxConnParams) -> Self {
-        let (closed_watch_tx, closed_watch_rx) = watch::channel(false);
-
-        Self {
-            closed_watch_rx,
-            inner: Arc::new(UDPMuxConnInner {
-                params,
-                closed_watch_tx: Mutex::new(Some(closed_watch_tx)),
-                addresses: Default::default(),
-                buffer: Buffer::new(0, 0),
-            }),
-        }
-    }
-
-    pub fn key(&self) -> &str {
-        &self.inner.params.key
-    }
-
-    pub async fn write_packet(&self, data: &[u8], addr: SocketAddr) -> ConnResult<()> {
-        // NOTE: Pion/ice uses Sync.Pool to optimise this.
-        let mut buffer = make_buffer();
-        let mut offset = 0;
-
-        if (data.len() + MAX_ADDR_SIZE) > (RECEIVE_MTU + MAX_ADDR_SIZE) {
-            return Err(Error::ErrBufferShort);
-        }
-
-        // Format of buffer: | data len(2) | data bytes(dn) | addr len(2) | addr bytes(an) |
-        // Where the number in parenthesis indicate the number of bytes used
-        // `dn` and `an` are the length in bytes of data and addr respectively.
-
-        // SAFETY: `data.len()` is at most RECEIVE_MTU(8192) - MAX_ADDR_SIZE(27)
-        buffer[0..2].copy_from_slice(&(data.len() as u16).to_le_bytes()[..]);
-        offset += 2;
-
-        buffer[offset..offset + data.len()].copy_from_slice(data);
-        offset += data.len();
-
-        let len = addr.encode(&mut buffer[offset + 2..])?;
-        buffer[offset..offset + 2].copy_from_slice(&(len as u16).to_le_bytes()[..]);
-        offset += 2 + len;
-
-        self.inner.buffer.write(&buffer[..offset]).await?;
-
-        Ok(())
-    }
-
-    pub fn is_closed(&self) -> bool {
-        self.inner.is_closed()
-    }
-
-    /// Get a copy of the close [`tokio::sync::watch::Receiver`] that fires when this
-    /// connection is closed.
-    pub fn close_rx(&self) -> watch::Receiver<bool> {
-        self.closed_watch_rx.clone()
-    }
-
-    /// Close this connection
-    pub fn close(&self) {
-        self.inner.close();
-    }
-
-    pub fn get_addresses(&self) -> Vec<SocketAddr> {
-        self.inner.get_addresses()
-    }
-
-    pub async fn add_address(&self, addr: SocketAddr) {
-        self.inner.add_address(addr);
-        self.inner
-            .params
-            .udp_mux
-            .register_conn_for_address(self, addr)
-            .await;
-    }
-
-    pub fn remove_address(&self, addr: &SocketAddr) {
-        self.inner.remove_address(addr)
-    }
-
-    pub fn contains_address(&self, addr: &SocketAddr) -> bool {
-        self.inner.contains_address(addr)
-    }
-}
-
-type ConnResult<T> = Result<T, util::Error>;
-
 #[async_trait]
 impl Conn for UDPMuxConn {
     async fn connect(&self, _addr: SocketAddr) -> ConnResult<()> {
@@ -286,4 +304,13 @@ impl Conn for UDPMuxConn {
 
         Ok(())
     }
+}
+
+#[inline(always)]
+/// Create a buffer of appropriate size to fit both a packet with max RECEIVE_MTU and the
+/// additional metadata used for muxing.
+fn make_buffer() -> Vec<u8> {
+    // The 4 extra bytes are used to encode the length of the data and address respectively.
+    // See [`write_packet`] for details.
+    vec![0u8; RECEIVE_MTU + MAX_ADDR_SIZE + 2 + 2]
 }

--- a/src/udp_mux/udp_mux_conn.rs
+++ b/src/udp_mux/udp_mux_conn.rs
@@ -32,7 +32,7 @@ pub struct UDPMuxConnParams {
     ///
     /// ```no_run
     /// let params = UDPMuxConnParams {
-    ///     udp_mux: Arc::downgrade(udp_mux_arc),
+    ///     udp_mux: Arc::downgrade(udp_mux_arc) as Weak<dyn UDPMuxWriter + Send + Sync>,
     ///     ...
     /// };
     /// ```


### PR DESCRIPTION
This PR exposes `UDPMuxConn` and `UDPMuxConnParams` structs to ease the development of alternative `UDPMux`'es (clones of `UDPMuxDefault` reusing the same components).

It changes the cyclic reference to udp_mux inside `UDPMuxConnParams` to be instead a non-owning reference to `dyn WeakUDPMux` trait, which requires two methods: `register_conn_for_address` and `send_to`.

NOTE: this change is not strictly necessary for this repo, but it would help my project (and possible others) in avoiding to copy the code of `UDPMuxConn` and `UDPMuxConnParams`.

Thanks 🙏 

Closes https://github.com/webrtc-rs/ice/issues/26