### PR TITLE
update deps + loosen some requirements

### DIFF
--- a/.github/workflows/cargo.yml
+++ b/.github/workflows/cargo.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.55.0
+          toolchain: stable
           profile: minimal
           components: clippy, rustfmt
           override: true
@@ -48,3 +48,22 @@ jobs:
         with:
           command: fmt
           args: --all -- --check
+
+  minimal_versions:
+    name: Compile and test with minimal versions
+    strategy:
+      matrix:
+        os: ['ubuntu-latest', 'macos-latest', 'windows-latest']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install latest nightly
+        uses: actions-rs/toolchain@v1
+        with:
+            toolchain: nightly
+            override: true
+      - uses: taiki-e/install-action@cargo-hack
+      - uses: taiki-e/install-action@cargo-minimal-versions
+      - run: cargo minimal-versions check --workspace --all-features --ignore-private -v
+      - run: cargo minimal-versions build --workspace --all-features --ignore-private -v
+      - run: cargo minimal-versions test --workspace --all-features -v

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ uuid = { version = "1.1", features = ["v4"] }
 waitgroup = "0.1.2"
 
 [dev-dependencies]
-tokio-test = "0.4.2"
+tokio-test = "0.4.0" # must match the min version of the `tokio` crate above
 regex = "1.5.4"
 env_logger = "0.9.0"
 chrono = "0.4.19"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,20 +12,20 @@ repository = "https://github.com/webrtc-rs/ice"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = "0.1.52"
-crc = "2.1.0"
-log = "0.4.14"
+async-trait = "0.1.56"
+crc = "3.0"
+log = "0.4"
 mdns = { package = "webrtc-mdns", version = "0.4.2" }
-rand = "0.8.4"
-serde = { version = "1.0.132", features = ["derive"] }
-serde_json = "1.0.73"
+rand = "0.8.5"
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 stun = "0.4.2"
-thiserror = "1.0.30"
-tokio = { version = "1.15.0", features = ["full"] }
+thiserror = "1.0"
+tokio = { version = "1.19", features = ["full"] }
 turn = "0.5.4"
-url = "2.2.2"
+url = "2.2"
 util = { package = "webrtc-util", version = "0.5.3", default-features = false, features = ["conn", "vnet", "sync"] }
-uuid = { version = "0.8.2", features = ["v4"] }
+uuid = { version = "1.1", features = ["v4"] }
 waitgroup = "0.1.2"
 
 [dev-dependencies]
@@ -33,10 +33,10 @@ tokio-test = "0.4.2"
 regex = "1.5.4"
 env_logger = "0.9.0"
 chrono = "0.4.19"
-ipnet = "2.3.1"
-clap = "2.34.0"
+ipnet = "2.5.0"
+clap = "3.2.6"
 lazy_static = "1.4.0"
-hyper = { version = "0.14.16", features = ["full"] }
+hyper = { version = "0.14.19", features = ["full"] }
 sha-1 = "0.10.0"
 
 [[example]]

--- a/examples/ping_pong.rs
+++ b/examples/ping_pong.rs
@@ -112,7 +112,7 @@ async fn main() -> Result<(), Error> {
             Arg::with_name("use-mux")
                 .takes_value(false)
                 .long("use-mux")
-                .short("m")
+                .short('m')
                 .help("Use a muxed UDP connection over a single listening port"),
         )
         .arg(


### PR DESCRIPTION
rules:
- for crates that are below v1.0 -> specify the precise version (unless
  readme says otherwise)
- If the code uses a feature that was added for example in X 0.3.17,
  then you should specify 0.3.17, which actually means "0.3.y where y >=
  17"
- for crates the are above or equal v1.0 -> specify only major version
  if the crate's API is minimal and won't change between minor versions
    (unless readme says otherwise) OR specify major&minor versions
    otherwise

tested with https://github.com/taiki-e/cargo-minimal-versions